### PR TITLE
[BTAT-1543] Added FinancialTransactionsService to call FinancialDataConnector

### DIFF
--- a/app/connectors/FinancialDataConnector.scala
+++ b/app/connectors/FinancialDataConnector.scala
@@ -16,7 +16,6 @@
 
 package connectors
 
-import java.time.LocalDate
 import javax.inject.{Inject, Singleton}
 
 import config.MicroserviceAppConfig
@@ -35,18 +34,18 @@ class FinancialDataConnector @Inject()(val http: HttpClient, val appConfig: Micr
   private[connectors] def financialDataUrl(regime: TaxRegime) =
     s"${appConfig.desUrl}/enterprise/financial-data/${regime.idType}/${regime.id}/${regime.regimeType}"
 
-  def getFinancialTransactions(regime: TaxRegime, queryParameters: FinancialDataQueryParameters)
-                              (implicit headerCarrier: HeaderCarrier, ec: ExecutionContext): Future[HttpGetResult[FinancialTransactions]] = {
+  def getFinancialData(regime: TaxRegime, queryParameters: FinancialDataQueryParameters)
+                      (implicit headerCarrier: HeaderCarrier, ec: ExecutionContext): Future[HttpGetResult[FinancialTransactions]] = {
 
     val url = financialDataUrl(regime)
     val desHC = headerCarrier.copy(authorization =Some(Authorization(s"Bearer ${appConfig.desToken}")))
       .withExtraHeaders("Environment" -> appConfig.desEnvironment)
 
-    Logger.debug(s"[FinancialDataConnector][getFinancialTransactions] - Calling GET $url \nHeaders: $desHC\n QueryParams: $queryParameters")
+    Logger.debug(s"[FinancialDataConnector][getFinancialData] - Calling GET $url \nHeaders: $desHC\n QueryParams: $queryParameters")
     http.GET(url, queryParameters.toSeqQueryParams)(FinancialTransactionsReads, desHC, ec).map {
       case financialTransactions@Right(_) => financialTransactions
       case error@Left(message) =>
-        Logger.warn("[FinancialDataConnector][getFinancialTransactions] DES Error Received. Message: " + message)
+        Logger.warn("[FinancialDataConnector][getFinancialData] DES Error Received. Message: " + message)
         error
     }
   }

--- a/app/models/FinancialDataQueryParameters.scala
+++ b/app/models/FinancialDataQueryParameters.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import java.time.LocalDate
+
+case class FinancialDataQueryParameters(fromDate: Option[LocalDate] = None,
+                                        toDate: Option[LocalDate] = None,
+                                        onlyOpenItems: Option[Boolean] = None,
+                                        includeLocks: Option[Boolean] = None,
+                                        calculateAccruedInterest: Option[Boolean] = None,
+                                        customerPaymentInformation: Option[Boolean] = None) {
+  val toSeqQueryParams: Seq[(String, String)] = Seq(
+    fromDate.map("dateFrom" -> _.toString),
+    toDate.map("dateTo" -> _.toString),
+    onlyOpenItems.map("onlyOpenItems" -> _.toString),
+    includeLocks.map("includeLocks" -> _.toString),
+    calculateAccruedInterest.map("calculateAccruedInterest" -> _.toString),
+    customerPaymentInformation.map("customerPaymentInformation" -> _.toString)
+  ).flatten
+}

--- a/app/services/FinancialTransactionsService.scala
+++ b/app/services/FinancialTransactionsService.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import java.time.LocalDate
+import javax.inject.{Inject, Singleton}
+
+import connectors.FinancialDataConnector
+import models.{DesErrors, FinancialDataQueryParameters, FinancialTransactions, TaxRegime}
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class FinancialTransactionsService @Inject()(val financialDataConnector: FinancialDataConnector) {
+
+  def getFinancialTransactions(regime: TaxRegime,
+                               fromDate: Option[LocalDate] = None,
+                               toDate: Option[LocalDate] = None,
+                               onlyOpenItems: Option[Boolean] = None,
+                               includeLocks: Option[Boolean] = None,
+                               calculateAccruedInterest: Option[Boolean] = None,
+                               customerPaymentInformation: Option[Boolean] = None
+                              )(implicit headerCarrier: HeaderCarrier, ec: ExecutionContext): Future[Either[DesErrors, FinancialTransactions]] = {
+    financialDataConnector.getFinancialTransactions(
+      regime,
+      FinancialDataQueryParameters(
+        fromDate,
+        toDate,
+        onlyOpenItems,
+        includeLocks,
+        calculateAccruedInterest,
+        customerPaymentInformation
+      )
+    )
+  }
+}

--- a/app/services/FinancialTransactionsService.scala
+++ b/app/services/FinancialTransactionsService.scala
@@ -36,7 +36,7 @@ class FinancialTransactionsService @Inject()(val financialDataConnector: Financi
                                calculateAccruedInterest: Option[Boolean] = None,
                                customerPaymentInformation: Option[Boolean] = None
                               )(implicit headerCarrier: HeaderCarrier, ec: ExecutionContext): Future[Either[DesErrors, FinancialTransactions]] = {
-    financialDataConnector.getFinancialTransactions(
+    financialDataConnector.getFinancialData(
       regime,
       FinancialDataQueryParameters(
         fromDate,

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -34,7 +34,7 @@ trait SpecBase extends UnitSpec with GuiceOneAppPerSuite {
 
   lazy val mockAppConfig: MicroserviceAppConfig = injector.instanceOf[MicroserviceAppConfig]
 
-  implicit val hc: HeaderCarrier = HeaderCarrier()
-  implicit val ec: ExecutionContext = injector.instanceOf[ExecutionContext]
+  implicit lazy val hc: HeaderCarrier = HeaderCarrier()
+  implicit lazy val ec: ExecutionContext = injector.instanceOf[ExecutionContext]
 
 }

--- a/test/connectors/FinancialDataConnectorSpec.scala
+++ b/test/connectors/FinancialDataConnectorSpec.scala
@@ -106,7 +106,7 @@ class FinancialDataConnectorSpec extends SpecBase with MockHttp {
       actualUrl shouldBe expectedUrl
     }
 
-    "when calling the getFinancialTransactions" when {
+    "when calling the getFinancialData" when {
 
       "calling for a VAT user with all Query Parameters defined and a success response received" should {
 
@@ -119,7 +119,7 @@ class FinancialDataConnectorSpec extends SpecBase with MockHttp {
             "calculateAccruedInterest" -> "false",
             "customerPaymentInformation" -> "false"
           ))(successResponse)
-          val result = TestFinancialDataConnector.getFinancialTransactions(
+          val result = TestFinancialDataConnector.getFinancialData(
             regime = vatRegime,
             queryParameters = FinancialDataQueryParameters(
               fromDate = Some("2017-04-06"),
@@ -140,7 +140,7 @@ class FinancialDataConnectorSpec extends SpecBase with MockHttp {
           setupMockHttpGet(TestFinancialDataConnector.financialDataUrl(vatRegime), Seq(
             "dateFrom" -> "2017-04-06"
           ))(successResponse)
-          val result = TestFinancialDataConnector.getFinancialTransactions(
+          val result = TestFinancialDataConnector.getFinancialData(
             regime = vatRegime,
             queryParameters = FinancialDataQueryParameters(
               fromDate = Some("2017-04-06")
@@ -154,7 +154,7 @@ class FinancialDataConnectorSpec extends SpecBase with MockHttp {
 
         "return a FinancialTransactions model" in {
           setupMockHttpGet(TestFinancialDataConnector.financialDataUrl(vatRegime), Seq("dateTo" -> "2018-04-05"))(successResponse)
-          val result = TestFinancialDataConnector.getFinancialTransactions(
+          val result = TestFinancialDataConnector.getFinancialData(
             regime = vatRegime,
             queryParameters = FinancialDataQueryParameters(
               toDate = Some("2018-04-05")
@@ -168,7 +168,7 @@ class FinancialDataConnectorSpec extends SpecBase with MockHttp {
 
         "return a FinancialTransactions model" in {
           setupMockHttpGet(TestFinancialDataConnector.financialDataUrl(vatRegime), Seq("onlyOpenItems" -> "true"))(successResponse)
-          val result = TestFinancialDataConnector.getFinancialTransactions(
+          val result = TestFinancialDataConnector.getFinancialData(
             regime = vatRegime,
             queryParameters = FinancialDataQueryParameters(
               onlyOpenItems = Some(true)
@@ -182,7 +182,7 @@ class FinancialDataConnectorSpec extends SpecBase with MockHttp {
 
         "return a FinancialTransactions model" in {
           setupMockHttpGet(TestFinancialDataConnector.financialDataUrl(vatRegime), Seq("includeLocks" -> "true"))(successResponse)
-          val result = TestFinancialDataConnector.getFinancialTransactions(
+          val result = TestFinancialDataConnector.getFinancialData(
             regime = vatRegime,
             queryParameters = FinancialDataQueryParameters(
               includeLocks = Some(true)
@@ -196,7 +196,7 @@ class FinancialDataConnectorSpec extends SpecBase with MockHttp {
 
         "return a FinancialTransactions model" in {
           setupMockHttpGet(TestFinancialDataConnector.financialDataUrl(vatRegime), Seq("calculateAccruedInterest" -> "false"))(successResponse)
-          val result = TestFinancialDataConnector.getFinancialTransactions(
+          val result = TestFinancialDataConnector.getFinancialData(
             regime = vatRegime,
             queryParameters = FinancialDataQueryParameters(
               calculateAccruedInterest = Some(false)
@@ -210,7 +210,7 @@ class FinancialDataConnectorSpec extends SpecBase with MockHttp {
 
         "return a FinancialTransactions model" in {
           setupMockHttpGet(TestFinancialDataConnector.financialDataUrl(vatRegime), Seq("customerPaymentInformation" -> "false"))(successResponse)
-          val result = TestFinancialDataConnector.getFinancialTransactions(
+          val result = TestFinancialDataConnector.getFinancialData(
             regime = vatRegime,
             queryParameters = FinancialDataQueryParameters(
               customerPaymentInformation = Some(false)
@@ -224,7 +224,7 @@ class FinancialDataConnectorSpec extends SpecBase with MockHttp {
 
         "return a FinancialTransactions model" in {
           setupMockHttpGet(TestFinancialDataConnector.financialDataUrl(vatRegime), Seq())(successResponse)
-          val result = TestFinancialDataConnector.getFinancialTransactions(regime = vatRegime, FinancialDataQueryParameters())
+          val result = TestFinancialDataConnector.getFinancialData(regime = vatRegime, FinancialDataQueryParameters())
           await(result) shouldBe successResponse
         }
       }
@@ -233,7 +233,7 @@ class FinancialDataConnectorSpec extends SpecBase with MockHttp {
 
         "return a DesError model" in {
           setupMockHttpGet(TestFinancialDataConnector.financialDataUrl(vatRegime), Seq())(badRequestSingleError)
-          val result = TestFinancialDataConnector.getFinancialTransactions(regime = vatRegime, FinancialDataQueryParameters())
+          val result = TestFinancialDataConnector.getFinancialData(regime = vatRegime, FinancialDataQueryParameters())
           await(result) shouldBe badRequestSingleError
         }
       }
@@ -242,7 +242,7 @@ class FinancialDataConnectorSpec extends SpecBase with MockHttp {
 
         "return a DesMultiError model" in {
           setupMockHttpGet(TestFinancialDataConnector.financialDataUrl(vatRegime), Seq())(badRequestMultiError)
-          val result = TestFinancialDataConnector.getFinancialTransactions(regime = vatRegime, FinancialDataQueryParameters())
+          val result = TestFinancialDataConnector.getFinancialData(regime = vatRegime, FinancialDataQueryParameters())
           await(result) shouldBe badRequestMultiError
         }
       }

--- a/test/connectors/FinancialDataConnectorSpec.scala
+++ b/test/connectors/FinancialDataConnectorSpec.scala
@@ -121,12 +121,14 @@ class FinancialDataConnectorSpec extends SpecBase with MockHttp {
           ))(successResponse)
           val result = TestFinancialDataConnector.getFinancialTransactions(
             regime = vatRegime,
-            fromDate = Some("2017-04-06"),
-            toDate = Some("2018-04-05"),
-            onlyOpenItems = Some(false),
-            includeLocks = Some(true),
-            calculateAccruedInterest = Some(false),
-            customerPaymentInformation = Some(false)
+            queryParameters = FinancialDataQueryParameters(
+              fromDate = Some("2017-04-06"),
+              toDate = Some("2018-04-05"),
+              onlyOpenItems = Some(false),
+              includeLocks = Some(true),
+              calculateAccruedInterest = Some(false),
+              customerPaymentInformation = Some(false)
+            )
           )
           await(result) shouldBe successResponse
         }
@@ -140,7 +142,9 @@ class FinancialDataConnectorSpec extends SpecBase with MockHttp {
           ))(successResponse)
           val result = TestFinancialDataConnector.getFinancialTransactions(
             regime = vatRegime,
-            fromDate = Some("2017-04-06")
+            queryParameters = FinancialDataQueryParameters(
+              fromDate = Some("2017-04-06")
+            )
           )
           await(result) shouldBe successResponse
         }
@@ -152,7 +156,9 @@ class FinancialDataConnectorSpec extends SpecBase with MockHttp {
           setupMockHttpGet(TestFinancialDataConnector.financialDataUrl(vatRegime), Seq("dateTo" -> "2018-04-05"))(successResponse)
           val result = TestFinancialDataConnector.getFinancialTransactions(
             regime = vatRegime,
-            toDate = Some("2018-04-05")
+            queryParameters = FinancialDataQueryParameters(
+              toDate = Some("2018-04-05")
+            )
           )
           await(result) shouldBe successResponse
         }
@@ -164,7 +170,9 @@ class FinancialDataConnectorSpec extends SpecBase with MockHttp {
           setupMockHttpGet(TestFinancialDataConnector.financialDataUrl(vatRegime), Seq("onlyOpenItems" -> "true"))(successResponse)
           val result = TestFinancialDataConnector.getFinancialTransactions(
             regime = vatRegime,
-            onlyOpenItems = Some(true)
+            queryParameters = FinancialDataQueryParameters(
+              onlyOpenItems = Some(true)
+            )
           )
           await(result) shouldBe successResponse
         }
@@ -176,7 +184,9 @@ class FinancialDataConnectorSpec extends SpecBase with MockHttp {
           setupMockHttpGet(TestFinancialDataConnector.financialDataUrl(vatRegime), Seq("includeLocks" -> "true"))(successResponse)
           val result = TestFinancialDataConnector.getFinancialTransactions(
             regime = vatRegime,
-            includeLocks = Some(true)
+            queryParameters = FinancialDataQueryParameters(
+              includeLocks = Some(true)
+            )
           )
           await(result) shouldBe successResponse
         }
@@ -188,7 +198,9 @@ class FinancialDataConnectorSpec extends SpecBase with MockHttp {
           setupMockHttpGet(TestFinancialDataConnector.financialDataUrl(vatRegime), Seq("calculateAccruedInterest" -> "false"))(successResponse)
           val result = TestFinancialDataConnector.getFinancialTransactions(
             regime = vatRegime,
-            calculateAccruedInterest = Some(false)
+            queryParameters = FinancialDataQueryParameters(
+              calculateAccruedInterest = Some(false)
+            )
           )
           await(result) shouldBe successResponse
         }
@@ -200,7 +212,9 @@ class FinancialDataConnectorSpec extends SpecBase with MockHttp {
           setupMockHttpGet(TestFinancialDataConnector.financialDataUrl(vatRegime), Seq("customerPaymentInformation" -> "false"))(successResponse)
           val result = TestFinancialDataConnector.getFinancialTransactions(
             regime = vatRegime,
-            customerPaymentInformation = Some(false)
+            queryParameters = FinancialDataQueryParameters(
+              customerPaymentInformation = Some(false)
+            )
           )
           await(result) shouldBe successResponse
         }
@@ -210,7 +224,7 @@ class FinancialDataConnectorSpec extends SpecBase with MockHttp {
 
         "return a FinancialTransactions model" in {
           setupMockHttpGet(TestFinancialDataConnector.financialDataUrl(vatRegime), Seq())(successResponse)
-          val result = TestFinancialDataConnector.getFinancialTransactions(regime = vatRegime)
+          val result = TestFinancialDataConnector.getFinancialTransactions(regime = vatRegime, FinancialDataQueryParameters())
           await(result) shouldBe successResponse
         }
       }
@@ -219,7 +233,7 @@ class FinancialDataConnectorSpec extends SpecBase with MockHttp {
 
         "return a DesError model" in {
           setupMockHttpGet(TestFinancialDataConnector.financialDataUrl(vatRegime), Seq())(badRequestSingleError)
-          val result = TestFinancialDataConnector.getFinancialTransactions(regime = vatRegime)
+          val result = TestFinancialDataConnector.getFinancialTransactions(regime = vatRegime, FinancialDataQueryParameters())
           await(result) shouldBe badRequestSingleError
         }
       }
@@ -228,7 +242,7 @@ class FinancialDataConnectorSpec extends SpecBase with MockHttp {
 
         "return a DesMultiError model" in {
           setupMockHttpGet(TestFinancialDataConnector.financialDataUrl(vatRegime), Seq())(badRequestMultiError)
-          val result = TestFinancialDataConnector.getFinancialTransactions(regime = vatRegime)
+          val result = TestFinancialDataConnector.getFinancialTransactions(regime = vatRegime, FinancialDataQueryParameters())
           await(result) shouldBe badRequestMultiError
         }
       }

--- a/test/mocks/connectors/MockFinancialDataConnector.scala
+++ b/test/mocks/connectors/MockFinancialDataConnector.scala
@@ -41,7 +41,7 @@ trait MockFinancialDataConnector extends UnitSpec with MockitoSugar with BeforeA
   def setupMockGetFinancialData(regime: TaxRegime, queryParameters: FinancialDataQueryParameters)
                                (response: Future[HttpGetResult[FinancialTransactions]]): OngoingStubbing[Future[HttpGetResult[FinancialTransactions]]] =
     when(
-      mockFinancialDataConnector.getFinancialTransactions(
+      mockFinancialDataConnector.getFinancialData(
         ArgumentMatchers.eq(regime),
         ArgumentMatchers.eq(queryParameters)
       )(ArgumentMatchers.any(), ArgumentMatchers.any())

--- a/test/mocks/connectors/MockFinancialDataConnector.scala
+++ b/test/mocks/connectors/MockFinancialDataConnector.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mocks.connectors
+
+import connectors.FinancialDataConnector
+import connectors.httpParsers.FinancialTransactionsHttpParser.HttpGetResult
+import models.{FinancialDataQueryParameters, FinancialTransactions, TaxRegime}
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito._
+import org.mockito.stubbing.OngoingStubbing
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.mockito.MockitoSugar
+import uk.gov.hmrc.play.test.UnitSpec
+
+import scala.concurrent.Future
+
+
+trait MockFinancialDataConnector extends UnitSpec with MockitoSugar with BeforeAndAfterEach {
+
+  val mockFinancialDataConnector: FinancialDataConnector = mock[FinancialDataConnector]
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    reset(mockFinancialDataConnector)
+  }
+
+  def setupMockGetFinancialData(regime: TaxRegime, queryParameters: FinancialDataQueryParameters)
+                               (response: Future[HttpGetResult[FinancialTransactions]]): OngoingStubbing[Future[HttpGetResult[FinancialTransactions]]] =
+    when(
+      mockFinancialDataConnector.getFinancialTransactions(
+        ArgumentMatchers.eq(regime),
+        ArgumentMatchers.eq(queryParameters)
+      )(ArgumentMatchers.any(), ArgumentMatchers.any())
+    ).thenReturn(Future.successful(response))
+}

--- a/test/models/FinancialDataQueryParametersSpec.scala
+++ b/test/models/FinancialDataQueryParametersSpec.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import base.SpecBase
+import utils.ImplicitDateFormatter._
+
+class FinancialDataQueryParametersSpec extends SpecBase {
+
+  "The FinancialDataQueryParameters.toSeqQueryParams method" should {
+
+    "output the expected sequence of key-value pairs" which {
+
+      "for no Query Parameters, has no values" in {
+        val queryParams = FinancialDataQueryParameters()
+        queryParams.toSeqQueryParams shouldBe Seq()
+      }
+
+      "for fromDate Query Param, has a 'dateFrom' param with correct value" in {
+        val queryParams = FinancialDataQueryParameters(fromDate = Some("2018-04-06"))
+        queryParams.toSeqQueryParams shouldBe Seq("dateFrom" -> "2018-04-06")
+      }
+
+      "for toDate Query Param, has a 'dateTo' param with correct value" in {
+        val queryParams = FinancialDataQueryParameters(toDate = Some("2019-04-05"))
+        queryParams.toSeqQueryParams shouldBe Seq("dateTo" -> "2019-04-05")
+      }
+
+      "for onlyOpenItems Query Param, has a 'onlyOpenItems' param with correct value" in {
+        val queryParams = FinancialDataQueryParameters(onlyOpenItems = Some(true))
+        queryParams.toSeqQueryParams shouldBe Seq("onlyOpenItems" -> "true")
+      }
+
+      "for includeLocks Query Param, has a 'includeLocks' param with correct value" in {
+        val queryParams = FinancialDataQueryParameters(includeLocks = Some(true))
+        queryParams.toSeqQueryParams shouldBe Seq("includeLocks" -> "true")
+      }
+
+      "for calculateAccruedInterest Query Param, has a 'calculateAccruedInterest' param with correct value" in {
+        val queryParams = FinancialDataQueryParameters(calculateAccruedInterest = Some(true))
+        queryParams.toSeqQueryParams shouldBe Seq("calculateAccruedInterest" -> "true")
+      }
+
+      "for customerPaymentInformation Query Param, has a 'customerPaymentInformation' param with correct value" in {
+        val queryParams = FinancialDataQueryParameters(customerPaymentInformation = Some(true))
+        queryParams.toSeqQueryParams shouldBe Seq("customerPaymentInformation" -> "true")
+      }
+
+      "for all Query Params, outputs them all as expected" in {
+        val queryParams = FinancialDataQueryParameters(
+          fromDate = Some("2017-04-06"),
+          toDate = Some("2018-04-05"),
+          onlyOpenItems = Some(false),
+          includeLocks = Some(true),
+          calculateAccruedInterest = Some(false),
+          customerPaymentInformation = Some(false)
+        )
+        queryParams.toSeqQueryParams shouldBe Seq(
+          "dateFrom" -> "2017-04-06",
+          "dateTo" -> "2018-04-05",
+          "onlyOpenItems" -> "false",
+          "includeLocks" -> "true",
+          "calculateAccruedInterest" -> "false",
+          "customerPaymentInformation" -> "false"
+        )
+      }
+    }
+  }
+}

--- a/test/services/FinancialTransactionsServiceSpec.scala
+++ b/test/services/FinancialTransactionsServiceSpec.scala
@@ -18,7 +18,8 @@ package services
 
 import base.SpecBase
 import mocks.connectors.MockFinancialDataConnector
-import models.{DesError, FinancialDataQueryParameters, VatRegime}
+import models._
+import utils.ImplicitDateFormatter._
 
 class FinancialTransactionsServiceSpec extends SpecBase with MockFinancialDataConnector {
 
@@ -29,16 +30,137 @@ class FinancialTransactionsServiceSpec extends SpecBase with MockFinancialDataCo
 
   "The FinancialTransactionService.getFinancialTransactions method" should {
 
-    "Return an error when a DesError is returned from the Connector" in {
+    "Return FiniancialTransactions when a DesError is returned from the Connector" in {
 
-      val expected = Left(DesError("CODE","REASON"))
-      setupMockGetFinancialData(regime, FinancialDataQueryParameters())(expected)
-      val actual = TestFinancialTransactionService.getFinancialTransactions(regime)
+      val successResponse = Right(FinancialTransactions(
+        idType = "MTDBSA",
+        idNumber = "XQIT00000000001",
+        regimeType = "ITSA",
+        processingDate = "2017-03-07T22:55:56.987Z",
+        financialTransactions = Seq(Transaction(
+          chargeType = Some("PAYE"),
+          mainType = Some("2100"),
+          periodKey = Some("13RL"),
+          periodKeyDescription = Some("abcde"),
+          taxPeriodFrom = Some("2017-4-6"),
+          taxPeriodTo = Some("2018-4-5"),
+          businessPartner = Some("6622334455"),
+          contractAccountCategory = Some("02"),
+          contractAccount = Some("X"),
+          contractObjectType = Some("ABCD"),
+          contractObject = Some("00000003000000002757"),
+          sapDocumentNumber = Some("1040000872"),
+          sapDocumentNumberItem = Some("XM00"),
+          chargeReference = Some("XM002610011594"),
+          mainTransaction = Some("1234"),
+          subTransaction = Some("5678"),
+          originalAmount = Some(3400.0),
+          outstandingAmount = Some(1400.0),
+          clearedAmount = Some(2000.0),
+          accruedInterest = Some(0.23),
+          items = Seq(SubItem(
+            subItem = Some("000"),
+            dueDate = Some("2018-2-14"),
+            amount = Some(3400.00),
+            clearingDate = Some("2018-2-17"),
+            clearingReason = Some("A"),
+            outgoingPaymentMethod = Some("B"),
+            paymentLock = Some("C"),
+            clearingLock = Some("D"),
+            interestLock = Some("E"),
+            dunningLock = Some("1"),
+            returnFlag = Some(false),
+            paymentReference = Some("F"),
+            paymentAmount = Some(2000.00),
+            paymentMethod = Some("G"),
+            paymentLot = Some("H"),
+            paymentLotItem = Some("112"),
+            clearingSAPDocument = Some("3350000253"),
+            statisticalDocument = Some("I"),
+            returnReason = Some("J"),
+            promiseToPay = Some("K")
+          ))
+        ))
+      ))
 
-      await(actual) shouldBe expected
+      setupMockGetFinancialData(regime, FinancialDataQueryParameters(
+        fromDate = Some("2017-04-06"),
+        toDate = Some("2018-04-05"),
+        onlyOpenItems = Some(false),
+        includeLocks = Some(true),
+        calculateAccruedInterest = Some(false),
+        customerPaymentInformation = Some(false)
+      ))(successResponse)
+
+      val actual = await(TestFinancialTransactionService.getFinancialTransactions(
+        regime,
+        fromDate = Some("2017-04-06"),
+        toDate = Some("2018-04-05"),
+        onlyOpenItems = Some(false),
+        includeLocks = Some(true),
+        calculateAccruedInterest = Some(false),
+        customerPaymentInformation = Some(false)
+      ))
+
+      actual shouldBe successResponse
 
     }
 
-  }
+    "Return an error when a DesError is returned from the Connector" in {
 
+      val singleErrorResponse = Left(DesError("CODE","REASON"))
+
+      setupMockGetFinancialData(regime, FinancialDataQueryParameters(
+        fromDate = Some("2017-04-06"),
+        toDate = Some("2018-04-05"),
+        onlyOpenItems = Some(false),
+        includeLocks = Some(true),
+        calculateAccruedInterest = Some(false),
+        customerPaymentInformation = Some(false)
+      ))(singleErrorResponse)
+
+      val actual = await(TestFinancialTransactionService.getFinancialTransactions(
+        regime,
+        fromDate = Some("2017-04-06"),
+        toDate = Some("2018-04-05"),
+        onlyOpenItems = Some(false),
+        includeLocks = Some(true),
+        calculateAccruedInterest = Some(false),
+        customerPaymentInformation = Some(false)
+      ))
+
+      actual shouldBe singleErrorResponse
+
+    }
+
+    "Return a DesMultiError when a multiple error response is returned from the Connector" in {
+
+      val multiErrorResponse = Left(DesMultiError(Seq(
+        DesError("CODE 1","REASON 1"),
+        DesError("CODE 2","REASON 2")
+      )))
+
+      setupMockGetFinancialData(regime, FinancialDataQueryParameters(
+        fromDate = Some("2017-04-06"),
+        toDate = Some("2018-04-05"),
+        onlyOpenItems = Some(false),
+        includeLocks = Some(true),
+        calculateAccruedInterest = Some(false),
+        customerPaymentInformation = Some(false)
+      ))(multiErrorResponse)
+
+      val actual = await(TestFinancialTransactionService.getFinancialTransactions(
+        regime,
+        fromDate = Some("2017-04-06"),
+        toDate = Some("2018-04-05"),
+        onlyOpenItems = Some(false),
+        includeLocks = Some(true),
+        calculateAccruedInterest = Some(false),
+        customerPaymentInformation = Some(false)
+      ))
+
+      actual shouldBe multiErrorResponse
+
+    }
+  }
 }

--- a/test/services/FinancialTransactionsServiceSpec.scala
+++ b/test/services/FinancialTransactionsServiceSpec.scala
@@ -28,7 +28,7 @@ class FinancialTransactionsServiceSpec extends SpecBase with MockFinancialDataCo
 
   lazy val regime = VatRegime("123456")
 
-  "The FinancialTransactionService.getFinancialTransactions method" should {
+  "The FinancialTransactionService.getFinancialData method" should {
 
     "Return FiniancialTransactions when a DesError is returned from the Connector" in {
 

--- a/test/services/FinancialTransactionsServiceSpec.scala
+++ b/test/services/FinancialTransactionsServiceSpec.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import base.SpecBase
+import mocks.connectors.MockFinancialDataConnector
+import models.{DesError, FinancialDataQueryParameters, VatRegime}
+
+class FinancialTransactionsServiceSpec extends SpecBase with MockFinancialDataConnector {
+
+
+  object TestFinancialTransactionService extends FinancialTransactionsService(mockFinancialDataConnector)
+
+  lazy val regime = VatRegime("123456")
+
+  "The FinancialTransactionService.getFinancialTransactions method" should {
+
+    "Return an error when a DesError is returned from the Connector" in {
+
+      val expected = Left(DesError("CODE","REASON"))
+      setupMockGetFinancialData(regime, FinancialDataQueryParameters())(expected)
+      val actual = TestFinancialTransactionService.getFinancialTransactions(regime)
+
+      await(actual) shouldBe expected
+
+    }
+
+  }
+
+}

--- a/test/services/FinancialTransactionsServiceSpec.scala
+++ b/test/services/FinancialTransactionsServiceSpec.scala
@@ -30,7 +30,7 @@ class FinancialTransactionsServiceSpec extends SpecBase with MockFinancialDataCo
 
   "The FinancialTransactionService.getFinancialData method" should {
 
-    "Return FiniancialTransactions when a DesError is returned from the Connector" in {
+    "Return FinancialTransactions when a success response is returned from the Connector" in {
 
       val successResponse = Right(FinancialTransactions(
         idType = "MTDBSA",
@@ -106,7 +106,7 @@ class FinancialTransactionsServiceSpec extends SpecBase with MockFinancialDataCo
 
     }
 
-    "Return an error when a DesError is returned from the Connector" in {
+    "Return DesError when a single error is returned from the Connector" in {
 
       val singleErrorResponse = Left(DesError("CODE","REASON"))
 
@@ -133,7 +133,7 @@ class FinancialTransactionsServiceSpec extends SpecBase with MockFinancialDataCo
 
     }
 
-    "Return a DesMultiError when a multiple error response is returned from the Connector" in {
+    "Return a DesMultiError when multiple error responses are returned from the Connector" in {
 
       val multiErrorResponse = Left(DesMultiError(Seq(
         DesError("CODE 1","REASON 1"),


### PR DESCRIPTION
- Refactored connector to utilise a `FinancialDataQueryParamemeter` model
- Renamed the `getFinancialTransactions` method on the connector to `getFinancialData`