### PR TITLE
BTAT-9271 Upgraded bootstrap-play and set explicit HTTP headers for DES calls

### DIFF
--- a/app/audit/AuditingService.scala
+++ b/app/audit/AuditingService.scala
@@ -80,7 +80,8 @@ class AuditingService @Inject()(appConfig: MicroserviceAppConfig, auditConnector
       detail = AuditExtensions.auditHeaderCarrier(hc).toAuditDetails(auditModel.detail: _*)
     )
 
-  def toDataEvent(appName: String, auditModel: ExtendedAuditModel, path: String)(implicit hc: HeaderCarrier): ExtendedDataEvent = {
+  def toDataEvent(appName: String, auditModel: ExtendedAuditModel, path: String)
+                 (implicit hc: HeaderCarrier): ExtendedDataEvent = {
 
     val details: JsValue =
       Json.toJson(AuditExtensions.auditHeaderCarrier(hc).toAuditDetails()).as[JsObject].deepMerge(auditModel.detail.as[JsObject])
@@ -93,5 +94,5 @@ class AuditingService @Inject()(appConfig: MicroserviceAppConfig, auditConnector
     )
   }
 
-  private def path(implicit hc: HeaderCarrier) = hc.headers.find(_._1 == REFERER).map(_._2).getOrElse("-")
+  private def path(implicit hc: HeaderCarrier) = hc.extraHeaders.find(_._1 == REFERER).map(_._2).getOrElse("-")
 }

--- a/app/controllers/actions/AuthAction.scala
+++ b/app/controllers/actions/AuthAction.scala
@@ -17,7 +17,6 @@
 package controllers.actions
 
 import javax.inject.Singleton
-
 import auth.AuthenticatedRequest
 import com.google.inject.Inject
 import models.{ForbiddenError, UnauthenticatedError}
@@ -28,7 +27,7 @@ import play.api.mvc._
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.play.HeaderCarrierConverter
+import uk.gov.hmrc.play.http.HeaderCarrierConverter
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -40,7 +39,7 @@ class AuthActionImpl @Inject()(val authorisedFunctions: AuthorisedFunctions, cc:
 
   override def invokeBlock[A](request: Request[A], block: AuthenticatedRequest[A] => Future[Result]): Future[Result] = {
 
-    implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromHeadersAndSession(request.headers)
+    implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromRequest(request)
 
     authorisedFunctions.authorised().retrieve(Retrievals.externalId) {
       case Some (externalId) => block(AuthenticatedRequest(request, externalId))

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,8 @@ lazy val coverageSettings: Seq[Setting[_]] = {
     "prod.*",
     "config.*",
     "testOnlyDoNotUseInAppConf.*",
-    "partials.*")
+    "partials.*"
+  )
 
   Seq(
     ScoverageKeys.coverageExcludedPackages := excludedPackages.mkString(";"),
@@ -56,7 +57,7 @@ lazy val coverageSettings: Seq[Setting[_]] = {
 
 val compile = Seq(
   ws,
-  "uk.gov.hmrc" %% "bootstrap-backend-play-26" % "2.24.0",
+  "uk.gov.hmrc" %% "bootstrap-backend-play-26" % "5.3.0",
   "com.typesafe.play" %% "play-json-joda" % "2.6.10"
 )
 
@@ -73,12 +74,12 @@ def test(scope: String = "test,it"): Seq[ModuleID] = Seq(
 
 def oneForkedJvmPerTest(tests: Seq[TestDefinition]) = {
   tests.map { test =>
-    new Group(test.name, Seq(test), SubProcess(ForkOptions().withRunJVMOptions(Vector(s"-Dtest.name=${test.name}"))))
+    Group(test.name, Seq(test), SubProcess(ForkOptions().withRunJVMOptions(Vector(s"-Dtest.name=${test.name}"))))
   }
 }
 
 lazy val microservice = Project(appName, file("."))
-  .enablePlugins(Seq(play.sbt.PlayScala, SbtAutoBuildPlugin, SbtGitVersioning, SbtDistributablesPlugin, SbtArtifactory) ++ plugins: _*)
+  .enablePlugins(Seq(play.sbt.PlayScala, SbtDistributablesPlugin) ++ plugins: _*)
   .settings(playSettings: _*)
   .settings(scalaSettings: _*)
   .settings(publishingSettings: _*)
@@ -101,8 +102,5 @@ lazy val microservice = Project(appName, file("."))
     unmanagedSourceDirectories in IntegrationTest := (baseDirectory in IntegrationTest) (base => Seq(base / "it")).value,
     addTestReportOption(IntegrationTest, "int-test-reports"),
     testGrouping in IntegrationTest := oneForkedJvmPerTest((definedTests in IntegrationTest).value),
-    parallelExecution in IntegrationTest := false)
-  .settings(resolvers ++= Seq(
-    Resolver.bintrayRepo("hmrc", "releases"),
-    Resolver.jcenterRepo
-  ))
+    parallelExecution in IntegrationTest := false
+  )

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -38,7 +38,6 @@ play.modules.enabled += "uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModu
 
 # Provides an implementation and configures all filters required by a Platform frontend microservice.
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.backend.BackendModule"
-play.http.filters = "uk.gov.hmrc.play.bootstrap.backend.filters.BackendFilters"
 
 # Json error handler
 play.http.errorHandler = handlers.ErrorHandler
@@ -62,7 +61,7 @@ play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
 # ~~~~~
 # The secret key is used to secure cryptographics functions.
 # If you deploy your application to several instances be sure to use the same key!
-play.crypto.secret = "30esigTW9wscKtfRMum2c5BaG2styhZLkrChqLcTFIoPCIs1gCvByhGW3RM1iTTx"
+play.http.secret.key = "30esigTW9wscKtfRMum2c5BaG2styhZLkrChqLcTFIoPCIs1gCvByhGW3RM1iTTx"
 
 # Session configuration
 # ~~~~~
@@ -103,24 +102,6 @@ controllers {
   }
 
 }
-
-# Evolutions
-# ~~~~~
-# You can disable evolutions if needed
-# evolutionplugin=disabled
-
-# Logger
-# ~~~~~
-# You can also configure logback (http://logback.qos.ch/), by providing a logger.xml file in the conf directory .
-
-# Root logger:
-logger.root = ERROR
-
-# Logger used by the framework:
-logger.play = INFO
-
-# Logger provided to your application:
-logger.application = DEBUG
 
 # Metrics plugin settings - graphite reporting is configured on a per env basis
 metrics {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,23 +14,14 @@
  * limitations under the License.
  */
 
-resolvers += Resolver.url("hmrc-sbt-plugin-releases", url("https://dl.bintray.com/hmrc/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
-
+resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefacts.tax.service.gov.uk/maven2")
+resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 resolvers += Resolver.url("HMRC Private Sbt Plugin Releases", url("https://artefacts.tax.service.gov.uk/artifactory/hmrc-sbt-plugin-releases-local"))(Resolver.ivyStylePatterns)
-
-
-resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
-
 resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/"
 
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.0.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.9.0")
-
-addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
-
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.3.0")
-
-addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.0.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.25")
 
@@ -38,4 +29,4 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-bobby" % "3.2.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-bobby" % "3.4.0")

--- a/test/audit/AuditingServiceSpec.scala
+++ b/test/audit/AuditingServiceSpec.scala
@@ -20,7 +20,9 @@ import audit.models.{AuditModel, ExtendedAuditModel}
 import base.SpecBase
 import mocks.audit.MockAuditingConnector
 import play.api.libs.json.{JsValue, Json}
+import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.audit.AuditExtensions
+import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 import uk.gov.hmrc.play.audit.http.connector.AuditResult.{Disabled, Failure, Success}
 import uk.gov.hmrc.play.audit.model.{DataEvent, ExtendedDataEvent}
 

--- a/test/mocks/MockHttp.scala
+++ b/test/mocks/MockHttp.scala
@@ -17,6 +17,7 @@
 package mocks
 
 import org.mockito.ArgumentMatchers
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 import org.mockito.stubbing.OngoingStubbing
 import org.scalatest.BeforeAndAfterEach
@@ -26,7 +27,6 @@ import uk.gov.hmrc.http.HttpClient
 import uk.gov.hmrc.play.test.UnitSpec
 
 import scala.concurrent.Future
-
 
 trait MockHttp extends UnitSpec with MockitoSugar with BeforeAndAfterEach {
 
@@ -38,14 +38,14 @@ trait MockHttp extends UnitSpec with MockitoSugar with BeforeAndAfterEach {
   }
 
   def setupMockHttpGet[A](url: String)(response: A): OngoingStubbing[Future[A]] =
-    when(mockHttpGet.GET[A](ArgumentMatchers.eq(url))(ArgumentMatchers.any(),
-      ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(response))
+    when(mockHttpGet.GET[A](ArgumentMatchers.eq(url), any(), any())(any(), any(), any()))
+      .thenReturn(Future.successful(response))
 
   def setupMockHttpGet[A](url: String, queryParams: Seq[(String, String)])(response: A): OngoingStubbing[Future[A]] =
-    when(mockHttpGet.GET[A](ArgumentMatchers.eq(url), ArgumentMatchers.eq(queryParams))(ArgumentMatchers.any(),
-      ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(response))
+    when(mockHttpGet.GET[A](ArgumentMatchers.eq(url), ArgumentMatchers.eq(queryParams), any())(any(),
+      any(), any())).thenReturn(Future.successful(response))
 
   def setupMockFailedHttpGet[A](url: String)(response: HttpResponse): OngoingStubbing[Future[A]] =
-    when(mockHttpGet.GET[A](ArgumentMatchers.eq(url))(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.failed(new Exception))
+    when(mockHttpGet.GET[A](ArgumentMatchers.eq(url))(any(), any(), any())).thenReturn(Future.failed(new Exception))
 
 }


### PR DESCRIPTION
I set the authorization inside the HeaderCarrier to None because by explicitly setting the authorization in the headers of the HTTP call itself, it meant that two authorization headers were being sent which produces a warning message from the HTTP library.