### PR TITLE
BTAT-10275 Added query param model & binder for API#1812

### DIFF
--- a/app/audit/models/FinancialTransactionsRequestAuditModel.scala
+++ b/app/audit/models/FinancialTransactionsRequestAuditModel.scala
@@ -17,9 +17,9 @@
 package audit.models
 
 import models._
-import models.RequestQueryParameters._
+import models.FinancialRequestQueryParameters._
 
-case class FinancialTransactionsRequestAuditModel(regime: TaxRegime, queryParams: RequestQueryParameters) extends AuditModel {
+case class FinancialTransactionsRequestAuditModel(regime: TaxRegime, queryParams: FinancialRequestQueryParameters) extends AuditModel {
 
   override val transactionName: String = "financial-transactions-request"
   override val auditType: String = "financialTransactionsRequest"

--- a/app/binders/FinancialTransactionsBinders.scala
+++ b/app/binders/FinancialTransactionsBinders.scala
@@ -19,17 +19,17 @@ package binders
 import java.net.URLEncoder
 import java.time.LocalDate
 
-import models.RequestQueryParameters._
-import models.RequestQueryParameters
+import models.FinancialRequestQueryParameters._
+import models.FinancialRequestQueryParameters
 import play.api.mvc.QueryStringBindable
 
 import scala.util.{Failure, Success, Try}
 
 object FinancialTransactionsBinders {
 
-  implicit def financialDataQueryBinder: QueryStringBindable[RequestQueryParameters] = {
-    new QueryStringBindable[RequestQueryParameters] {
-      override def bind(key: String, params: Map[String, Seq[String]]): Option[Either[String, RequestQueryParameters]] = {
+  implicit def financialDataQueryBinder: QueryStringBindable[FinancialRequestQueryParameters] = {
+    new QueryStringBindable[FinancialRequestQueryParameters] {
+      override def bind(key: String, params: Map[String, Seq[String]]): Option[Either[String, FinancialRequestQueryParameters]] = {
         val bindFrom = dateBind(dateFromKey, params)
         val bindTo = dateBind(dateToKey, params)
         val bindOnlyOpenItems = boolBind(onlyOpenItemsKey, params)
@@ -39,13 +39,13 @@ object FinancialTransactionsBinders {
 
         queryParams match {
           case (Right(from), Right(to), Right(openItems)) =>
-            Some(Right(RequestQueryParameters(from, to, openItems)))
+            Some(Right(FinancialRequestQueryParameters(from, to, openItems)))
           case _ =>
             Some(Left(seqParams.collect{ case _@Left(errorMessage) => errorMessage }.mkString(", ")))
         }
       }
 
-      override def unbind(key: String, params: RequestQueryParameters): String = params.toSeqQueryParams.map {
+      override def unbind(key: String, params: FinancialRequestQueryParameters): String = params.toSeqQueryParams.map {
         case (paramKey, paramValue) => s"$paramKey=${URLEncoder.encode(paramValue, "utf-8")}"
       }.mkString("&")
 

--- a/app/binders/PenaltyDetailsBinders.scala
+++ b/app/binders/PenaltyDetailsBinders.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package binders
+
+import models.PenaltyDetailsQueryParameters
+import models.PenaltyDetailsQueryParameters.dateLimitKey
+import play.api.mvc.QueryStringBindable
+
+import java.net.URLEncoder
+import scala.util.{Success, Try}
+
+object PenaltyDetailsBinders {
+
+  implicit def penaltyDetailsQueryBinder: QueryStringBindable[PenaltyDetailsQueryParameters] = {
+    new QueryStringBindable[PenaltyDetailsQueryParameters] {
+      override def bind(key: String, params: Map[String, Seq[String]]): Option[Either[String, PenaltyDetailsQueryParameters]] = {
+        val bindDateLimit = dateLimitBind(dateLimitKey, params)
+
+        val queryParams = bindDateLimit
+        val seqParams = Seq(bindDateLimit)
+
+        queryParams match {
+          case Right(dateLimit) =>
+            Some(Right(PenaltyDetailsQueryParameters(dateLimit)))
+          case _ =>
+            Some(Left(seqParams.collect { case _@Left(errorMessage) => errorMessage }.mkString(", ")))
+        }
+      }
+
+      override def unbind(key: String, params: PenaltyDetailsQueryParameters): String = params.toSeqQueryParams.map {
+        case (paramKey, paramValue) => s"$paramKey=${URLEncoder.encode(paramValue, "utf-8")}"
+      }.mkString("&")
+
+      private[binders] def dateLimitBind(key: String, params: Map[String, Seq[String]]) = params.get(key) match {
+        case Some(values) => Try(values.head.toInt) match {
+          case Success(x) if x >= 0 & x <= 99 => Right(Some(x))
+          case _ => Left(s"Failed to bind '$key=${values.headOption.getOrElse("")}' valid values are between 0 and 99 inclusive.")
+        }
+        case _ => Right(None)
+      }
+    }
+  }
+}

--- a/app/connectors/API1166/FinancialDataConnector.scala
+++ b/app/connectors/API1166/FinancialDataConnector.scala
@@ -21,7 +21,7 @@ import connectors.API1166.httpParsers.FinancialTransactionsHttpParser._
 import connectors.httpParsers.DirectDebitCheckHttpParser.DirectDebitCheckReads
 import javax.inject.{Inject, Singleton}
 import models.API1166.FinancialTransactions
-import models.{DirectDebits, RequestQueryParameters, TaxRegime}
+import models.{DirectDebits, FinancialRequestQueryParameters, TaxRegime}
 import play.api.http.Status.NOT_FOUND
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
 import utils.LoggerUtil
@@ -39,7 +39,7 @@ class FinancialDataConnector @Inject()(val http: HttpClient, val appConfig: Micr
 
   val desHeaders = Seq("Authorization" -> s"Bearer ${appConfig.desToken}", "Environment" -> appConfig.desEnvironment)
 
-  def getFinancialData(regime: TaxRegime, queryParameters: RequestQueryParameters)
+  def getFinancialData(regime: TaxRegime, queryParameters: FinancialRequestQueryParameters)
                       (implicit headerCarrier: HeaderCarrier, ec: ExecutionContext): Future[HttpGetResult[FinancialTransactions]] = {
 
     val url = financialDataUrl(regime)

--- a/app/connectors/API1811/FinancialDataConnector.scala
+++ b/app/connectors/API1811/FinancialDataConnector.scala
@@ -21,7 +21,7 @@ import java.util.UUID.randomUUID
 import config.MicroserviceAppConfig
 import connectors.API1811.httpParsers.FinancialTransactionsHttpParser.{FinancialTransactionsReads, FinancialTransactionsResponse}
 import javax.inject.{Inject, Singleton}
-import models.{RequestQueryParameters, TaxRegime}
+import models.{FinancialRequestQueryParameters, TaxRegime}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
 import utils.LoggerUtil
 
@@ -33,7 +33,7 @@ class FinancialDataConnector @Inject()(val http: HttpClient, val appConfig: Micr
   private[connectors] def financialDataUrl(regime: TaxRegime) =
     s"${appConfig.eisUrl}/penalty/financial-data/${regime.idType}/${regime.id}/${regime.regimeType}"
 
-  def getFinancialData(regime: TaxRegime, queryParameters: RequestQueryParameters)
+  def getFinancialData(regime: TaxRegime, queryParameters: FinancialRequestQueryParameters)
                          (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[FinancialTransactionsResponse] = {
 
     val eisHeaders = Seq("CorrelationId" -> randomUUID().toString, "Environment" -> appConfig.eisEnvironment)

--- a/app/controllers/FinancialTransactionsController.scala
+++ b/app/controllers/FinancialTransactionsController.scala
@@ -40,7 +40,7 @@ class FinancialTransactionsController @Inject()(val authenticate: AuthAction,
 
   def getFinancialTransactions(idType: String,
                                idValue: String,
-                               queryParams: RequestQueryParameters): Action[AnyContent] =
+                               queryParams: FinancialRequestQueryParameters): Action[AnyContent] =
     authenticate.async {
       implicit authorisedUser =>
       if(appConfig.features.useApi1811()) {
@@ -63,7 +63,7 @@ class FinancialTransactionsController @Inject()(val authenticate: AuthAction,
       }
     }
 
-  private def retrieveFinancialTransactions(regime: TaxRegime, queryParams: RequestQueryParameters)
+  private def retrieveFinancialTransactions(regime: TaxRegime, queryParams: FinancialRequestQueryParameters)
                                            (implicit hc: HeaderCarrier) = {
     logger.debug(s"[FinancialTransactionsController][retrieveFinancialTransactions] " +
       "Calling FinancialTransactionsService.getFinancialTransactions")
@@ -77,7 +77,7 @@ class FinancialTransactionsController @Inject()(val authenticate: AuthAction,
     }
   }
 
-  private def retrieveFinancialTransactionsAPI1811(regime: TaxRegime, queryParams: RequestQueryParameters)
+  private def retrieveFinancialTransactionsAPI1811(regime: TaxRegime, queryParams: FinancialRequestQueryParameters)
                                                   (implicit hc: HeaderCarrier) = {
     logger.debug(s"[FinancialTransactionsController][retrieveFinancialTransactionsAPI1811] " +
       "Calling API1811.FinancialTransactionsService.getFinancialTransactions")

--- a/app/models/FinancialRequestQueryParameters.scala
+++ b/app/models/FinancialRequestQueryParameters.scala
@@ -20,10 +20,10 @@ import java.time.LocalDate
 
 import play.api.libs.json.{Format, Json}
 
-case class RequestQueryParameters(fromDate: Option[LocalDate] = None,
-                                  toDate: Option[LocalDate] = None,
-                                  onlyOpenItems: Option[Boolean] = None) {
-  import RequestQueryParameters._
+case class FinancialRequestQueryParameters(fromDate: Option[LocalDate] = None,
+                                           toDate: Option[LocalDate] = None,
+                                           onlyOpenItems: Option[Boolean] = None) {
+  import FinancialRequestQueryParameters._
   val toSeqQueryParams: Seq[(String, String)] = Seq(
     fromDate.map(dateFromKey -> _.toString),
     toDate.map(dateToKey -> _.toString),
@@ -46,7 +46,7 @@ case class RequestQueryParameters(fromDate: Option[LocalDate] = None,
 
 }
 
-object RequestQueryParameters {
+object FinancialRequestQueryParameters {
 
   val dateFromKey = "dateFrom"
   val dateToKey = "dateTo"
@@ -56,5 +56,5 @@ object RequestQueryParameters {
   val calculateAccruedInterestKey = "calculateAccruedInterest"
   val customerPaymentInformationKey = "customerPaymentInformation"
 
-  implicit val format: Format[RequestQueryParameters] = Json.format[RequestQueryParameters]
+  implicit val format: Format[FinancialRequestQueryParameters] = Json.format[FinancialRequestQueryParameters]
 }

--- a/app/models/PenaltyDetailsQueryParameters.scala
+++ b/app/models/PenaltyDetailsQueryParameters.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import models.PenaltyDetailsQueryParameters.dateLimitKey
+
+case class PenaltyDetailsQueryParameters(dateLimit: Option[Int] = None) {
+
+  val toSeqQueryParams: Seq[(String, String)] = Seq(dateLimit.map(dateLimitKey -> _.toString)).flatten
+}
+
+object PenaltyDetailsQueryParameters {
+  val dateLimitKey = "dateLimit"
+}

--- a/app/services/API1166/FinancialTransactionsService.scala
+++ b/app/services/API1166/FinancialTransactionsService.scala
@@ -32,7 +32,7 @@ class FinancialTransactionsService @Inject()(val financialDataConnector: Financi
                                              val auditingService: AuditingService) extends LoggerUtil {
 
   def getFinancialTransactions(regime: TaxRegime,
-                               queryParameters: RequestQueryParameters)
+                               queryParameters: FinancialRequestQueryParameters)
                               (implicit headerCarrier: HeaderCarrier,
                                ec: ExecutionContext): Future[Either[ErrorResponse, FinancialTransactions]] = {
 

--- a/app/services/API1811/FinancialTransactionsService.scala
+++ b/app/services/API1811/FinancialTransactionsService.scala
@@ -19,7 +19,7 @@ package services.API1811
 import com.google.inject.Inject
 import connectors.API1811.FinancialDataConnector
 import connectors.API1811.httpParsers.FinancialTransactionsHttpParser.FinancialTransactionsResponse
-import models.{RequestQueryParameters, TaxRegime}
+import models.{FinancialRequestQueryParameters, TaxRegime}
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.LoggerUtil
 
@@ -28,7 +28,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class FinancialTransactionsService @Inject()(val connector: FinancialDataConnector,
                                              implicit val ec: ExecutionContext) extends LoggerUtil {
 
-  def getFinancialTransactions(regime: TaxRegime, queryParameters: RequestQueryParameters)(
+  def getFinancialTransactions(regime: TaxRegime, queryParameters: FinancialRequestQueryParameters)(
                                implicit headerCarrier: HeaderCarrier): Future[FinancialTransactionsResponse] = {
 
     logger.debug("[FinancialTransactionsService][getFinancialTransactions] " +

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -2,4 +2,4 @@
 
 GET /has-direct-debit/:vrn @controllers.FinancialTransactionsController.checkDirectDebitExists(vrn: String)
 
-GET /:idType/:idValue   @controllers.FinancialTransactionsController.getFinancialTransactions(idType: String, idValue: String, queryParams: models.RequestQueryParameters)
+GET /:idType/:idValue   @controllers.FinancialTransactionsController.getFinancialTransactions(idType: String, idValue: String, queryParams: models.FinancialRequestQueryParameters)

--- a/it/connectors/API1811/FinancialDataConnectorISpec.scala
+++ b/it/connectors/API1811/FinancialDataConnectorISpec.scala
@@ -20,7 +20,7 @@ import connectors.API1811
 import connectors.API1811.httpParsers.FinancialTransactionsHttpParser.FinancialTransactionsResponse
 import helpers.ComponentSpecBase
 import models.API1811.Error
-import models.{RequestQueryParameters, TaxRegime, VatRegime}
+import models.{FinancialRequestQueryParameters, TaxRegime, VatRegime}
 import play.api.http.Status._
 import play.api.libs.json.Json
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
@@ -41,7 +41,7 @@ class FinancialDataConnectorISpec extends ComponentSpecBase {
   val invalidRegime: TaxRegime = VatRegime(id = "9")
   val vrn = "123456789"
   val invalidVrn = "9"
-  val queryParameters: RequestQueryParameters = RequestQueryParameters()
+  val queryParameters: FinancialRequestQueryParameters = FinancialRequestQueryParameters()
 
   def generateUrl(regimeType: String, VRN : String): String =  s"/penalty/financial-data/VRN/$VRN/$regimeType" +
     s"?onlyOpenItems=false&includeLocks=true&calculateAccruedInterest=true&removePOA=true&customerPaymentInformation=true"

--- a/it/controllers/FinancialTransactionsComponentSpec.scala
+++ b/it/controllers/FinancialTransactionsComponentSpec.scala
@@ -20,7 +20,7 @@ import config.RegimeKeys
 import helpers.ComponentSpecBase
 import helpers.servicemocks.{DesFinancialDataStub, EISFinancialDataStub}
 import models.API1166._
-import models.{IncomeTaxRegime, RequestQueryParameters, VatRegime}
+import models.{IncomeTaxRegime, FinancialRequestQueryParameters, VatRegime}
 import play.api.http.Status._
 import play.api.libs.json.Json
 import testData.{FinancialData1166, FinancialData1811}
@@ -35,7 +35,7 @@ class FinancialTransactionsComponentSpec extends ComponentSpecBase {
 
       "a successful response is returned by the API" should {
 
-        lazy val queryParameters = RequestQueryParameters(onlyOpenItems = Some(true))
+        lazy val queryParameters = FinancialRequestQueryParameters(onlyOpenItems = Some(true))
 
         "return a success response" in {
 
@@ -59,7 +59,7 @@ class FinancialTransactionsComponentSpec extends ComponentSpecBase {
 
       "an unsuccessful response is returned by the API" should {
 
-        lazy val queryParameters = RequestQueryParameters()
+        lazy val queryParameters = FinancialRequestQueryParameters()
 
         "return a single error response" in {
 
@@ -89,7 +89,7 @@ class FinancialTransactionsComponentSpec extends ComponentSpecBase {
 
         "a successful response is returned by the API" should {
 
-          lazy val queryParameters = RequestQueryParameters()
+          lazy val queryParameters = FinancialRequestQueryParameters()
 
           "return a success response" in {
 
@@ -116,7 +116,7 @@ class FinancialTransactionsComponentSpec extends ComponentSpecBase {
 
         "a bad request response is returned by the API, containing one error" should {
 
-          lazy val queryParameters = RequestQueryParameters()
+          lazy val queryParameters = FinancialRequestQueryParameters()
 
           "return a single error response" in {
 
@@ -142,7 +142,7 @@ class FinancialTransactionsComponentSpec extends ComponentSpecBase {
 
         "a bad request response is returned by the API, containing multiple errors" should {
 
-          lazy val queryParameters = RequestQueryParameters()
+          lazy val queryParameters = FinancialRequestQueryParameters()
 
           "return a multi error response model" in {
 
@@ -174,7 +174,7 @@ class FinancialTransactionsComponentSpec extends ComponentSpecBase {
             isAuthorised(false)
 
             When(s"I call GET /financial-transactions/it/$mtditid")
-            val res = FinancialTransactions.getFinancialTransactions(RegimeKeys.IT, incomeTaxRegime.id, RequestQueryParameters())
+            val res = FinancialTransactions.getFinancialTransactions(RegimeKeys.IT, incomeTaxRegime.id, FinancialRequestQueryParameters())
 
             res should have(
               httpStatus(FORBIDDEN)
@@ -190,7 +190,7 @@ class FinancialTransactionsComponentSpec extends ComponentSpecBase {
 
         "a successful response is returned by the API" should {
 
-          lazy val queryParameters = RequestQueryParameters()
+          lazy val queryParameters = FinancialRequestQueryParameters()
 
           "return a success response" in {
 
@@ -216,7 +216,7 @@ class FinancialTransactionsComponentSpec extends ComponentSpecBase {
 
         "a bad request response is returned by the API, containing one error" should {
 
-          lazy val queryParameters = RequestQueryParameters()
+          lazy val queryParameters = FinancialRequestQueryParameters()
 
           "return a single error response" in {
 
@@ -242,7 +242,7 @@ class FinancialTransactionsComponentSpec extends ComponentSpecBase {
 
         "a bad request response is returned by the API, containing multiple errors" should {
 
-          lazy val queryParameters = RequestQueryParameters()
+          lazy val queryParameters = FinancialRequestQueryParameters()
 
           "return a multi error response model" in {
 
@@ -273,7 +273,7 @@ class FinancialTransactionsComponentSpec extends ComponentSpecBase {
             isAuthorised(false)
 
             When(s"I call GET /financial-transactions/vat/$vrn")
-            val res = FinancialTransactions.getFinancialTransactions(RegimeKeys.VAT, vatRegime.id, RequestQueryParameters())
+            val res = FinancialTransactions.getFinancialTransactions(RegimeKeys.VAT, vatRegime.id, FinancialRequestQueryParameters())
 
             res should have(
               httpStatus(FORBIDDEN)

--- a/it/helpers/ComponentSpecBase.scala
+++ b/it/helpers/ComponentSpecBase.scala
@@ -21,7 +21,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, get, stubFor}
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import config.MicroserviceAppConfig
 import helpers.servicemocks.AuthStub
-import models.RequestQueryParameters
+import models.FinancialRequestQueryParameters
 import org.scalatest._
 import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
@@ -72,7 +72,7 @@ trait ComponentSpecBase extends TestSuite with CustomMatchers
 
   object FinancialTransactions {
     def get(uri: String): WSResponse = await(buildClient(uri).get())
-    def getFinancialTransactions(idType: String, id: String, queryParameters: RequestQueryParameters): WSResponse = {
+    def getFinancialTransactions(idType: String, id: String, queryParameters: FinancialRequestQueryParameters): WSResponse = {
       val queryParamStart = if(queryParameters.hasQueryParameters) "?" else ""
       get(s"/financial-transactions/$idType/$id$queryParamStart" +
         FinancialTransactionsBinders.financialDataQueryBinder.unbind("", queryParameters))

--- a/it/helpers/servicemocks/DesFinancialDataStub.scala
+++ b/it/helpers/servicemocks/DesFinancialDataStub.scala
@@ -19,12 +19,12 @@ package helpers.servicemocks
 import binders.FinancialTransactionsBinders
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import helpers.WiremockHelper._
-import models.{RequestQueryParameters, TaxRegime}
+import models.{FinancialRequestQueryParameters, TaxRegime}
 import play.api.libs.json.JsValue
 
 object DesFinancialDataStub {
 
-  private def financialDataUrl(regime: TaxRegime, queryParameters: RequestQueryParameters): String = {
+  private def financialDataUrl(regime: TaxRegime, queryParameters: FinancialRequestQueryParameters): String = {
     if (queryParameters.hasQueryParameters) {
       s"/enterprise/financial-data/${regime.idType}/${regime.id}/${regime.regimeType}" +
         s"?${FinancialTransactionsBinders.financialDataQueryBinder.unbind("", queryParameters)}"
@@ -34,10 +34,10 @@ object DesFinancialDataStub {
     }
   }
 
-  def stubGetFinancialData(regime: TaxRegime, queryParams: RequestQueryParameters)(status: Int, response: JsValue): StubMapping =
+  def stubGetFinancialData(regime: TaxRegime, queryParams: FinancialRequestQueryParameters)(status: Int, response: JsValue): StubMapping =
     stubGet(financialDataUrl(regime, queryParams), status, response.toString())
 
-  def verifyGetDesBusinessDetails(regime: TaxRegime, queryParams: RequestQueryParameters): Unit =
+  def verifyGetDesBusinessDetails(regime: TaxRegime, queryParams: FinancialRequestQueryParameters): Unit =
     verifyGet(financialDataUrl(regime, queryParams))
 
 }

--- a/it/helpers/servicemocks/EISFinancialDataStub.scala
+++ b/it/helpers/servicemocks/EISFinancialDataStub.scala
@@ -19,12 +19,12 @@ package helpers.servicemocks
 import binders.FinancialTransactionsBinders
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import helpers.WiremockHelper.stubGet
-import models.{RequestQueryParameters, TaxRegime}
+import models.{FinancialRequestQueryParameters, TaxRegime}
 import play.api.libs.json.JsValue
 
 object EISFinancialDataStub {
 
-  private def financialDataUrl(regime: TaxRegime, requestQueryParams: RequestQueryParameters): String =
+  private def financialDataUrl(regime: TaxRegime, requestQueryParams: FinancialRequestQueryParameters): String =
     if(requestQueryParams.hasQueryParameters) {
       s"/penalty/financial-data/${regime.idType}/${regime.id}/${regime.regimeType}" +
         s"?${FinancialTransactionsBinders.financialDataQueryBinder.unbind("", requestQueryParams)}" +
@@ -34,7 +34,7 @@ object EISFinancialDataStub {
         "?onlyOpenItems=false&includeLocks=true&calculateAccruedInterest=true&removePOA=true&customerPaymentInformation=true"
     }
 
-  def stubGetFinancialData(regime: TaxRegime, queryParams: RequestQueryParameters)
+  def stubGetFinancialData(regime: TaxRegime, queryParams: FinancialRequestQueryParameters)
                           (status: Int, response: JsValue): StubMapping =
     stubGet(financialDataUrl(regime, queryParams), status, response.toString())
 }

--- a/test/appRoutes/AppRoutesSpec.scala
+++ b/test/appRoutes/AppRoutesSpec.scala
@@ -17,7 +17,7 @@
 package appRoutes
 
 import base.SpecBase
-import models.RequestQueryParameters
+import models.FinancialRequestQueryParameters
 import utils.ImplicitDateFormatter._
 
 class AppRoutesSpec extends SpecBase {
@@ -31,7 +31,7 @@ class AppRoutesSpec extends SpecBase {
 
       "no query parameters are supplied" should {
 
-        lazy val queryParams = RequestQueryParameters()
+        lazy val queryParams = FinancialRequestQueryParameters()
 
         val expected = "/financial-transactions/vat/123456"
 
@@ -43,7 +43,7 @@ class AppRoutesSpec extends SpecBase {
 
       "'dateFrom' query parameter is supplied" should {
 
-        lazy val queryParams = RequestQueryParameters(Some("2018-02-01"))
+        lazy val queryParams = FinancialRequestQueryParameters(Some("2018-02-01"))
 
         val expected = "/financial-transactions/vat/123456?dateFrom=2018-02-01"
 
@@ -55,7 +55,7 @@ class AppRoutesSpec extends SpecBase {
 
       "'dateFrom, dateTo' query parameters are supplied" should {
 
-        lazy val queryParams = RequestQueryParameters(Some("2018-02-01"), Some("2019-03-01"))
+        lazy val queryParams = FinancialRequestQueryParameters(Some("2018-02-01"), Some("2019-03-01"))
 
         val expected = "/financial-transactions/vat/123456?dateFrom=2018-02-01&dateTo=2019-03-01"
 
@@ -67,7 +67,7 @@ class AppRoutesSpec extends SpecBase {
 
       "all query parameters are supplied" should {
 
-        lazy val queryParams = RequestQueryParameters(
+        lazy val queryParams = FinancialRequestQueryParameters(
           fromDate = Some("2018-02-01"),
           toDate = Some("2019-03-01"),
           onlyOpenItems = Some(true)

--- a/test/audit/models/FinancialTransactionsRequestAuditModelSpec.scala
+++ b/test/audit/models/FinancialTransactionsRequestAuditModelSpec.scala
@@ -16,9 +16,9 @@
 
 package audit.models
 
-import _root_.models.{RequestQueryParameters, _}
+import _root_.models.{FinancialRequestQueryParameters, _}
 import base.SpecBase
-import models.RequestQueryParameters._
+import models.FinancialRequestQueryParameters._
 import utils.ImplicitDateFormatter._
 
 class FinancialTransactionsRequestAuditModelSpec extends SpecBase {
@@ -32,7 +32,7 @@ class FinancialTransactionsRequestAuditModelSpec extends SpecBase {
 
     "all QueryParameters are passed to it" should {
 
-      val testQueryParams = RequestQueryParameters(
+      val testQueryParams = FinancialRequestQueryParameters(
         fromDate = Some("2018-01-01"),
         toDate = Some("2019-01-01"),
         onlyOpenItems = Some(true)
@@ -60,7 +60,7 @@ class FinancialTransactionsRequestAuditModelSpec extends SpecBase {
 
     "not passed any Query Parameters" should {
 
-      val noQueryParams = RequestQueryParameters()
+      val noQueryParams = FinancialRequestQueryParameters()
       object TestFinancialTransactionsRequestAuditModel extends FinancialTransactionsRequestAuditModel(testRegime, noQueryParams)
 
       "Have the correct details for the audit event" in {

--- a/test/binders/FinancialTransactionsBindersSpec.scala
+++ b/test/binders/FinancialTransactionsBindersSpec.scala
@@ -17,8 +17,8 @@
 package binders
 
 import base.SpecBase
-import models.RequestQueryParameters._
-import models.RequestQueryParameters
+import models.FinancialRequestQueryParameters._
+import models.FinancialRequestQueryParameters
 import utils.ImplicitDateFormatter._
 
 class FinancialTransactionsBindersSpec extends SpecBase {
@@ -29,9 +29,9 @@ class FinancialTransactionsBindersSpec extends SpecBase {
 
       val queryParams: Map[String, Seq[String]] = Map("" -> Seq())
 
-      "return an empty RequestQueryParameters instance" in {
+      "return an empty FinancialRequestQueryParameters instance" in {
 
-        val expected = Some(Right(RequestQueryParameters()))
+        val expected = Some(Right(FinancialRequestQueryParameters()))
         val actual = FinancialTransactionsBinders.financialDataQueryBinder.bind("", queryParams)
 
         actual shouldBe expected
@@ -45,9 +45,9 @@ class FinancialTransactionsBindersSpec extends SpecBase {
 
         val queryParams: Map[String, Seq[String]] = Map(dateFromKey -> Seq("2018-01-01"))
 
-        "return an RequestQueryParameters instance with correct parameters" in {
+        "return a FinancialRequestQueryParameters instance with correct parameters" in {
 
-          val expected = Some(Right(RequestQueryParameters(Some("2018-01-01"))))
+          val expected = Some(Right(FinancialRequestQueryParameters(Some("2018-01-01"))))
           val actual = FinancialTransactionsBinders.financialDataQueryBinder.bind("", queryParams)
 
           actual shouldBe expected
@@ -75,9 +75,9 @@ class FinancialTransactionsBindersSpec extends SpecBase {
 
         val queryParams: Map[String, Seq[String]] = Map(dateToKey -> Seq("2018-01-01"))
 
-        "return an RequestQueryParameters instance with correct parameters" in {
+        "return a FinancialRequestQueryParameters instance with correct parameters" in {
 
-          val expected = Some(Right(RequestQueryParameters(None, Some("2018-01-01"))))
+          val expected = Some(Right(FinancialRequestQueryParameters(None, Some("2018-01-01"))))
           val actual = FinancialTransactionsBinders.financialDataQueryBinder.bind("", queryParams)
 
           actual shouldBe expected
@@ -105,9 +105,9 @@ class FinancialTransactionsBindersSpec extends SpecBase {
 
         val queryParams: Map[String, Seq[String]] = Map(onlyOpenItemsKey -> Seq("true"))
 
-        "return an RequestQueryParameters instance with correct parameters" in {
+        "return a FinancialRequestQueryParameters instance with correct parameters" in {
 
-          val expected = Some(Right(RequestQueryParameters(None, None, Some(true))))
+          val expected = Some(Right(FinancialRequestQueryParameters(None, None, Some(true))))
           val actual = FinancialTransactionsBinders.financialDataQueryBinder.bind("", queryParams)
 
           actual shouldBe expected
@@ -138,9 +138,9 @@ class FinancialTransactionsBindersSpec extends SpecBase {
           onlyOpenItemsKey -> Seq("true")
         )
 
-        "return an RequestQueryParameters instance with correct parameters" in {
+        "return a FinancialRequestQueryParameters instance with correct parameters" in {
 
-          val expected = Some(Right(RequestQueryParameters(
+          val expected = Some(Right(FinancialRequestQueryParameters(
             fromDate = Some("2018-01-01"),
             toDate = Some("2018-01-01"),
             onlyOpenItems = Some(true)
@@ -179,9 +179,9 @@ class FinancialTransactionsBindersSpec extends SpecBase {
 
       val queryParams: Map[String, Seq[String]] = Map("unrecognisedDateParam" -> Seq("2018-01-01"))
 
-      "ignore it and return an empty RequestQueryParameters instance" in {
+      "ignore it and return an empty FinancialRequestQueryParameters instance" in {
 
-        val expected = Some(Right(RequestQueryParameters()))
+        val expected = Some(Right(FinancialRequestQueryParameters()))
         val actual = FinancialTransactionsBinders.financialDataQueryBinder.bind("", queryParams)
 
         actual shouldBe expected

--- a/test/binders/PenaltyDetailsBindersSpec.scala
+++ b/test/binders/PenaltyDetailsBindersSpec.scala
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package binders
+
+import base.SpecBase
+import models.PenaltyDetailsQueryParameters
+import models.PenaltyDetailsQueryParameters.dateLimitKey
+
+class PenaltyDetailsBindersSpec extends SpecBase {
+
+  "The PenaltyDetailsBinders.penaltyDetailsQueryBinder.bind method" when {
+
+    "no query parameters are passed" should {
+
+      "return an empty PenaltyDetailsQueryParameters instance" in {
+        val queryParams: Map[String, Seq[String]] = Map("" -> Seq())
+        val expected = Some(Right(PenaltyDetailsQueryParameters()))
+        val actual = PenaltyDetailsBinders.penaltyDetailsQueryBinder.bind("", queryParams)
+
+        actual shouldBe expected
+      }
+    }
+
+    "a dateLimit query parameter is passed" should {
+
+      "return a PenaltyDetailsQueryParameters instance with correct parameters" when {
+
+        "the value is 0 (lower boundary)" in {
+          val queryParams: Map[String, Seq[String]] = Map(dateLimitKey -> Seq("0"))
+          val expected = Some(Right(PenaltyDetailsQueryParameters(Some(0))))
+          val actual = PenaltyDetailsBinders.penaltyDetailsQueryBinder.bind("", queryParams)
+
+          actual shouldBe expected
+        }
+
+        "the value is 99 (upper boundary)" in {
+          val queryParams: Map[String, Seq[String]] = Map(dateLimitKey -> Seq("99"))
+          val expected = Some(Right(PenaltyDetailsQueryParameters(Some(99))))
+          val actual = PenaltyDetailsBinders.penaltyDetailsQueryBinder.bind("", queryParams)
+
+          actual shouldBe expected
+        }
+
+        "the value is between 0 and 99" in {
+          val queryParams: Map[String, Seq[String]] = Map(dateLimitKey -> Seq("47"))
+          val expected = Some(Right(PenaltyDetailsQueryParameters(Some(47))))
+          val actual = PenaltyDetailsBinders.penaltyDetailsQueryBinder.bind("", queryParams)
+
+          actual shouldBe expected
+        }
+      }
+
+      "return an error message with details of the error" when {
+
+        "the value is negative" in {
+          val queryParams: Map[String, Seq[String]] = Map(dateLimitKey -> Seq("-1"))
+          val expected = Some(Left(s"Failed to bind '$dateLimitKey=-1' valid values are between 0 and 99 inclusive."))
+          val actual = PenaltyDetailsBinders.penaltyDetailsQueryBinder.bind("", queryParams)
+
+          actual shouldBe expected
+        }
+
+        "the value is greater than 99" in {
+          val queryParams: Map[String, Seq[String]] = Map(dateLimitKey -> Seq("100"))
+          val expected = Some(Left(s"Failed to bind '$dateLimitKey=100' valid values are between 0 and 99 inclusive."))
+          val actual = PenaltyDetailsBinders.penaltyDetailsQueryBinder.bind("", queryParams)
+
+          actual shouldBe expected
+        }
+
+        "the value is not numeric" in {
+          val queryParams: Map[String, Seq[String]] = Map(dateLimitKey -> Seq("hello"))
+          val expected = Some(Left(s"Failed to bind '$dateLimitKey=hello' valid values are between 0 and 99 inclusive."))
+          val actual = PenaltyDetailsBinders.penaltyDetailsQueryBinder.bind("", queryParams)
+
+          actual shouldBe expected
+        }
+      }
+    }
+
+    "if an unrecognised query parameter is passed" should {
+
+      "ignore it and return an empty PenaltyDetailsQueryParameters instance" in {
+        val queryParams: Map[String, Seq[String]] = Map("unrecognisedParam" -> Seq("2018-01-01"))
+        val expected = Some(Right(PenaltyDetailsQueryParameters()))
+        val actual = PenaltyDetailsBinders.penaltyDetailsQueryBinder.bind("", queryParams)
+
+        actual shouldBe expected
+      }
+    }
+  }
+
+  "The PenaltyDetailsBinders.penaltyDetailsQueryBinder.unbind method" should {
+
+    "unbind query parameters correctly" in {
+      val queryParams = PenaltyDetailsQueryParameters(Some(1))
+      val result = PenaltyDetailsBinders.penaltyDetailsQueryBinder.unbind("", queryParams)
+
+      result shouldBe "dateLimit=1"
+    }
+  }
+}

--- a/test/connectors/API1166/FinancialDataConnectorSpec.scala
+++ b/test/connectors/API1166/FinancialDataConnectorSpec.scala
@@ -21,7 +21,7 @@ import connectors.API1166.httpParsers.FinancialTransactionsHttpParser
 import mocks.MockHttp
 import models.API1166._
 import models._
-import models.RequestQueryParameters._
+import models.FinancialRequestQueryParameters._
 import play.api.http.Status
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import utils.ImplicitDateFormatter._
@@ -88,7 +88,7 @@ class FinancialDataConnectorSpec extends SpecBase with MockHttp {
           val result: Future[FinancialTransactionsHttpParser.HttpGetResult[FinancialTransactions]] =
             TestFinancialDataConnector.getFinancialData(
               regime = vatRegime,
-              queryParameters = RequestQueryParameters(
+              queryParameters = FinancialRequestQueryParameters(
                 fromDate = Some("2017-04-06"),
                 toDate = Some("2018-04-05"),
                 onlyOpenItems = Some(false)
@@ -107,7 +107,7 @@ class FinancialDataConnectorSpec extends SpecBase with MockHttp {
           val result: Future[FinancialTransactionsHttpParser.HttpGetResult[FinancialTransactions]] =
             TestFinancialDataConnector.getFinancialData(
               regime = vatRegime,
-              queryParameters = RequestQueryParameters(
+              queryParameters = FinancialRequestQueryParameters(
                 fromDate = Some("2017-04-06")
               )
             )
@@ -123,7 +123,7 @@ class FinancialDataConnectorSpec extends SpecBase with MockHttp {
           val result: Future[FinancialTransactionsHttpParser.HttpGetResult[FinancialTransactions]] =
             TestFinancialDataConnector.getFinancialData(
               regime = vatRegime,
-              queryParameters = RequestQueryParameters(
+              queryParameters = FinancialRequestQueryParameters(
                 toDate = Some("2018-04-05")
               )
             )
@@ -138,7 +138,7 @@ class FinancialDataConnectorSpec extends SpecBase with MockHttp {
             Seq(onlyOpenItemsKey -> "true"))(successResponse)
           val result = TestFinancialDataConnector.getFinancialData(
             regime = vatRegime,
-            queryParameters = RequestQueryParameters(
+            queryParameters = FinancialRequestQueryParameters(
               onlyOpenItems = Some(true)
             )
           )
@@ -151,7 +151,7 @@ class FinancialDataConnectorSpec extends SpecBase with MockHttp {
         "return a FinancialTransactions model" in {
           setupMockHttpGet(TestFinancialDataConnector.financialDataUrl(vatRegime), Seq())(successResponse)
           val result: Future[FinancialTransactionsHttpParser.HttpGetResult[FinancialTransactions]] =
-            TestFinancialDataConnector.getFinancialData(regime = vatRegime, RequestQueryParameters())
+            TestFinancialDataConnector.getFinancialData(regime = vatRegime, FinancialRequestQueryParameters())
           await(result) shouldBe successResponse
         }
       }
@@ -161,7 +161,7 @@ class FinancialDataConnectorSpec extends SpecBase with MockHttp {
         "return a Error model" in {
           setupMockHttpGet(TestFinancialDataConnector.financialDataUrl(vatRegime), Seq())(badRequestSingleError)
           val result: Future[FinancialTransactionsHttpParser.HttpGetResult[FinancialTransactions]] =
-            TestFinancialDataConnector.getFinancialData(regime = vatRegime, RequestQueryParameters())
+            TestFinancialDataConnector.getFinancialData(regime = vatRegime, FinancialRequestQueryParameters())
           await(result) shouldBe badRequestSingleError
         }
       }
@@ -171,7 +171,7 @@ class FinancialDataConnectorSpec extends SpecBase with MockHttp {
         "return a MultiError model" in {
           setupMockHttpGet(TestFinancialDataConnector.financialDataUrl(vatRegime), Seq())(badRequestMultiError)
           val result: Future[FinancialTransactionsHttpParser.HttpGetResult[FinancialTransactions]] =
-            TestFinancialDataConnector.getFinancialData(regime = vatRegime, RequestQueryParameters())
+            TestFinancialDataConnector.getFinancialData(regime = vatRegime, FinancialRequestQueryParameters())
           await(result) shouldBe badRequestMultiError
         }
       }

--- a/test/controllers/FinancialTransactionsControllerSpec.scala
+++ b/test/controllers/FinancialTransactionsControllerSpec.scala
@@ -25,7 +25,7 @@ import mocks.services.MockFinancialTransactionsService
 import mocks.services.Mock1811FinancialTransactionsService
 import models.API1166._
 import models.API1811.{Error => Error1811}
-import models.{RequestQueryParameters, _}
+import models.{FinancialRequestQueryParameters, _}
 import play.api.http.Status
 import play.api.libs.json.Json
 import play.api.test.Helpers.{contentAsJson, defaultAwaitTimeout, status}
@@ -73,12 +73,12 @@ class FinancialTransactionsControllerSpec extends SpecBase
             lazy val result = {
               mockAppConfig.features.useApi1811(false)
               TestFinancialTransactionController.getFinancialTransactions(
-                regimeType, vrn, RequestQueryParameters()
+                regimeType, vrn, FinancialRequestQueryParameters()
               )(fakeRequest)
             }
 
             "return a status of 200 (OK)" in {
-              setupMockGetFinancialTransactions(vatRegime, RequestQueryParameters())(successResponse)
+              setupMockGetFinancialTransactions(vatRegime, FinancialRequestQueryParameters())(successResponse)
               status(result) shouldBe Status.OK
             }
 
@@ -91,11 +91,11 @@ class FinancialTransactionsControllerSpec extends SpecBase
           "for a bad request with single error from the FinancialTransactionsService" should {
 
             lazy val result = TestFinancialTransactionController.getFinancialTransactions(
-              regimeType, vrn, RequestQueryParameters()
+              regimeType, vrn, FinancialRequestQueryParameters()
             )(fakeRequest)
 
             "return a status of 400 (BAD_REQUEST)" in {
-              setupMockGetFinancialTransactions(vatRegime, RequestQueryParameters())(badRequestSingleError)
+              setupMockGetFinancialTransactions(vatRegime, FinancialRequestQueryParameters())(badRequestSingleError)
               status(result) shouldBe Status.BAD_REQUEST
             }
 
@@ -108,11 +108,11 @@ class FinancialTransactionsControllerSpec extends SpecBase
           "for a bad request with multiple errors from the FinancialTransactionsService" should {
 
             lazy val result = TestFinancialTransactionController.getFinancialTransactions(
-              regimeType, vrn, RequestQueryParameters()
+              regimeType, vrn, FinancialRequestQueryParameters()
             )(fakeRequest)
 
             "return a status of 400 (BAD_REQUEST)" in {
-              setupMockGetFinancialTransactions(vatRegime, RequestQueryParameters())(badRequestMultiError)
+              setupMockGetFinancialTransactions(vatRegime, FinancialRequestQueryParameters())(badRequestMultiError)
               status(result) shouldBe Status.BAD_REQUEST
             }
 
@@ -132,11 +132,11 @@ class FinancialTransactionsControllerSpec extends SpecBase
           "for a successful response from the FinancialTransactionsService" should {
 
             lazy val result = TestFinancialTransactionController.getFinancialTransactions(
-              regimeType, mtditid, RequestQueryParameters()
+              regimeType, mtditid, FinancialRequestQueryParameters()
             )(fakeRequest)
 
             "return a status of 200 (OK)" in {
-              setupMockGetFinancialTransactions(incomeTaxRegime, RequestQueryParameters())(successResponse)
+              setupMockGetFinancialTransactions(incomeTaxRegime, FinancialRequestQueryParameters())(successResponse)
               status(result) shouldBe Status.OK
             }
 
@@ -149,11 +149,11 @@ class FinancialTransactionsControllerSpec extends SpecBase
           "for a bad request with single error from the FinancialTransactionsService" should {
 
             lazy val result = TestFinancialTransactionController.getFinancialTransactions(
-              regimeType, mtditid, RequestQueryParameters()
+              regimeType, mtditid, FinancialRequestQueryParameters()
             )(fakeRequest)
 
             "return a status of 400 (BAD_REQUEST)" in {
-              setupMockGetFinancialTransactions(incomeTaxRegime, RequestQueryParameters())(badRequestSingleError)
+              setupMockGetFinancialTransactions(incomeTaxRegime, FinancialRequestQueryParameters())(badRequestSingleError)
               status(result) shouldBe Status.BAD_REQUEST
             }
 
@@ -166,11 +166,11 @@ class FinancialTransactionsControllerSpec extends SpecBase
           "for a bad request with multiple errors from the FinancialTransactionsService" should {
 
             lazy val result = TestFinancialTransactionController.getFinancialTransactions(
-              regimeType, mtditid, RequestQueryParameters()
+              regimeType, mtditid, FinancialRequestQueryParameters()
             )(fakeRequest)
 
             "return a status of 400 (BAD_REQUEST)" in {
-              setupMockGetFinancialTransactions(incomeTaxRegime, RequestQueryParameters())(badRequestMultiError)
+              setupMockGetFinancialTransactions(incomeTaxRegime, FinancialRequestQueryParameters())(badRequestMultiError)
               status(result) shouldBe Status.BAD_REQUEST
             }
 
@@ -188,7 +188,7 @@ class FinancialTransactionsControllerSpec extends SpecBase
           val id = "123456"
 
           lazy val result = TestFinancialTransactionController.getFinancialTransactions(
-            regimeType, id, RequestQueryParameters()
+            regimeType, id, FinancialRequestQueryParameters()
           )(fakeRequest)
 
           "return a status of 400 (BAD_REQUEST)" in {
@@ -209,7 +209,7 @@ class FinancialTransactionsControllerSpec extends SpecBase
         "Return an UNAUTHORISED response" which {
 
           lazy val result = TestFinancialTransactionController.getFinancialTransactions(
-            regimeType, id, RequestQueryParameters()
+            regimeType, id, FinancialRequestQueryParameters()
           )(fakeRequest)
 
           "has status UNAUTHORISED (401)" in {
@@ -235,9 +235,9 @@ class FinancialTransactionsControllerSpec extends SpecBase
 
             lazy val result = {
               mockAppConfig.features.useApi1811(true)
-              setupMock1811GetFinancialTransactions(vatRegime, RequestQueryParameters())(successResponse)
+              setupMock1811GetFinancialTransactions(vatRegime, FinancialRequestQueryParameters())(successResponse)
               TestFinancialTransactionController.getFinancialTransactions(
-                regimeType, id, RequestQueryParameters()
+                regimeType, id, FinancialRequestQueryParameters()
               )(fakeRequest)
             }
 
@@ -254,9 +254,9 @@ class FinancialTransactionsControllerSpec extends SpecBase
 
             lazy val result = {
               mockAppConfig.features.useApi1811(true)
-              setupMock1811GetFinancialTransactions(vatRegime, RequestQueryParameters())(errorResponse)
+              setupMock1811GetFinancialTransactions(vatRegime, FinancialRequestQueryParameters())(errorResponse)
               TestFinancialTransactionController.getFinancialTransactions(
-                regimeType, id, RequestQueryParameters()
+                regimeType, id, FinancialRequestQueryParameters()
               )(fakeRequest)
             }
 
@@ -278,9 +278,9 @@ class FinancialTransactionsControllerSpec extends SpecBase
 
           lazy val result = {
             mockAppConfig.features.useApi1811(true)
-            setupMock1811GetFinancialTransactions(vatRegime, RequestQueryParameters())(errorResponse)
+            setupMock1811GetFinancialTransactions(vatRegime, FinancialRequestQueryParameters())(errorResponse)
             TestFinancialTransactionController.getFinancialTransactions(
-              regimeType, id, RequestQueryParameters()
+              regimeType, id, FinancialRequestQueryParameters()
             )(fakeRequest)
           }
 
@@ -360,7 +360,7 @@ class FinancialTransactionsControllerSpec extends SpecBase
       "Return an UNAUTHORISED response" which {
 
         lazy val result = TestFinancialTransactionController.getFinancialTransactions(
-          regimeType, id, RequestQueryParameters()
+          regimeType, id, FinancialRequestQueryParameters()
         )(fakeRequest)
 
         "has status UNAUTHORISED (401)" in {

--- a/test/mocks/connectors/Mock1166FinancialDataConnector.scala
+++ b/test/mocks/connectors/Mock1166FinancialDataConnector.scala
@@ -19,7 +19,7 @@ package mocks.connectors
 import connectors.API1166.FinancialDataConnector
 import connectors.API1166.httpParsers.FinancialTransactionsHttpParser.HttpGetResult
 import models.API1166.FinancialTransactions
-import models.{DirectDebits, RequestQueryParameters, TaxRegime}
+import models.{DirectDebits, FinancialRequestQueryParameters, TaxRegime}
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.mockito.stubbing.OngoingStubbing
@@ -40,7 +40,7 @@ trait Mock1166FinancialDataConnector extends AnyWordSpecLike with Matchers with 
     reset(mockFinancialDataConnector)
   }
 
-  def setupMockGetFinancialData(regime: TaxRegime, queryParameters: RequestQueryParameters)
+  def setupMockGetFinancialData(regime: TaxRegime, queryParameters: FinancialRequestQueryParameters)
                                (response: HttpGetResult[FinancialTransactions]): OngoingStubbing[Future[HttpGetResult[FinancialTransactions]]] =
     when(
       mockFinancialDataConnector.getFinancialData(

--- a/test/mocks/connectors/Mock1811FinancialDataConnector.scala
+++ b/test/mocks/connectors/Mock1811FinancialDataConnector.scala
@@ -18,7 +18,7 @@ package mocks.connectors
 
 import connectors.API1811.FinancialDataConnector
 import connectors.API1811.httpParsers.FinancialTransactionsHttpParser.FinancialTransactionsResponse
-import models.{RequestQueryParameters, TaxRegime}
+import models.{FinancialRequestQueryParameters, TaxRegime}
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito.when
 import org.mockito.stubbing.OngoingStubbing
@@ -30,7 +30,7 @@ trait Mock1811FinancialDataConnector {
 
   val mockFinancialDataConnector: FinancialDataConnector = mock[FinancialDataConnector]
 
-  def setupMockGetFinancialData(regime: TaxRegime, queryParameters: RequestQueryParameters)
+  def setupMockGetFinancialData(regime: TaxRegime, queryParameters: FinancialRequestQueryParameters)
                                (response: FinancialTransactionsResponse): OngoingStubbing[Future[FinancialTransactionsResponse]] =
     when(
       mockFinancialDataConnector.getFinancialData(

--- a/test/mocks/services/Mock1811FinancialTransactionsService.scala
+++ b/test/mocks/services/Mock1811FinancialTransactionsService.scala
@@ -17,7 +17,7 @@
 package mocks.services
 
 import connectors.API1811.httpParsers.FinancialTransactionsHttpParser.FinancialTransactionsResponse
-import models.{RequestQueryParameters, TaxRegime}
+import models.{FinancialRequestQueryParameters, TaxRegime}
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito.when
 import org.mockito.stubbing.OngoingStubbing
@@ -30,7 +30,7 @@ trait Mock1811FinancialTransactionsService {
 
   val mock1811FinancialTransactionsService: api1811FinancialTransactionsService = mock[api1811FinancialTransactionsService]
 
-  def setupMock1811GetFinancialTransactions(regime: TaxRegime, queryParameters: RequestQueryParameters)
+  def setupMock1811GetFinancialTransactions(regime: TaxRegime, queryParameters: FinancialRequestQueryParameters)
                                        (response: FinancialTransactionsResponse): OngoingStubbing[Future[FinancialTransactionsResponse]] =
     when(
       mock1811FinancialTransactionsService.getFinancialTransactions(

--- a/test/mocks/services/MockFinancialTransactionsService.scala
+++ b/test/mocks/services/MockFinancialTransactionsService.scala
@@ -18,7 +18,7 @@ package mocks.services
 
 import connectors.API1166.httpParsers.FinancialTransactionsHttpParser.HttpGetResult
 import models.API1166.FinancialTransactions
-import models.{DirectDebits, RequestQueryParameters, TaxRegime}
+import models.{DirectDebits, FinancialRequestQueryParameters, TaxRegime}
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito.{reset, when}
 import org.mockito.stubbing.OngoingStubbing
@@ -39,7 +39,7 @@ trait MockFinancialTransactionsService extends AnyWordSpecLike with Matchers wit
     reset(mockFinancialTransactionsService)
   }
 
-  def setupMockGetFinancialTransactions(regime: TaxRegime, queryParameters: RequestQueryParameters)
+  def setupMockGetFinancialTransactions(regime: TaxRegime, queryParameters: FinancialRequestQueryParameters)
                                (response: HttpGetResult[FinancialTransactions]): OngoingStubbing[Future[HttpGetResult[FinancialTransactions]]] =
     when(
       mockFinancialTransactionsService.getFinancialTransactions(

--- a/test/models/FinancialRequestQueryParametersSpec.scala
+++ b/test/models/FinancialRequestQueryParametersSpec.scala
@@ -18,9 +18,9 @@ package models
 
 import base.SpecBase
 import utils.ImplicitDateFormatter._
-import RequestQueryParameters._
+import FinancialRequestQueryParameters._
 
-class RequestQueryParametersSpec extends SpecBase {
+class FinancialRequestQueryParametersSpec extends SpecBase {
 
   "The FinancialDataQueryParameters object" should {
 
@@ -42,27 +42,27 @@ class RequestQueryParametersSpec extends SpecBase {
     "output the expected sequence of key-value pairs" which {
 
       "for no Query Parameters, has no values" in {
-        val queryParams = RequestQueryParameters()
+        val queryParams = FinancialRequestQueryParameters()
         queryParams.toSeqQueryParams shouldBe Seq()
       }
 
       "for fromDate Query Param, has a 'dateFrom' param with correct value" in {
-        val queryParams = RequestQueryParameters(fromDate = Some("2018-04-06"))
+        val queryParams = FinancialRequestQueryParameters(fromDate = Some("2018-04-06"))
         queryParams.toSeqQueryParams shouldBe Seq(dateFromKey -> "2018-04-06")
       }
 
       "for toDate Query Param, has a 'dateTo' param with correct value" in {
-        val queryParams = RequestQueryParameters(toDate = Some("2019-04-05"))
+        val queryParams = FinancialRequestQueryParameters(toDate = Some("2019-04-05"))
         queryParams.toSeqQueryParams shouldBe Seq(dateToKey -> "2019-04-05")
       }
 
       "for onlyOpenItems Query Param, has a 'onlyOpenItems' param with correct value" in {
-        val queryParams = RequestQueryParameters(onlyOpenItems = Some(true))
+        val queryParams = FinancialRequestQueryParameters(onlyOpenItems = Some(true))
         queryParams.toSeqQueryParams shouldBe Seq(onlyOpenItemsKey -> "true")
       }
 
       "for all Query Params, outputs them all as expected" in {
-        val queryParams = RequestQueryParameters(
+        val queryParams = FinancialRequestQueryParameters(
           fromDate = Some("2017-04-06"),
           toDate = Some("2018-04-05"),
           onlyOpenItems = Some(false)
@@ -80,7 +80,7 @@ class RequestQueryParametersSpec extends SpecBase {
     "output the expected sequence of key value pairs" which {
 
       "if only open items is defined it should be added to the sequence" in {
-        val queryParams = RequestQueryParameters(
+        val queryParams = FinancialRequestQueryParameters(
           fromDate = Some("2017-04-06"),
           toDate = Some("2018-04-05"),
           onlyOpenItems = Some(true)
@@ -96,7 +96,7 @@ class RequestQueryParametersSpec extends SpecBase {
         )
       }
       "if only open items is not defined in the request it should be added to the sequence and set to false" in {
-        val queryParams = RequestQueryParameters(
+        val queryParams = FinancialRequestQueryParameters(
           fromDate = Some("2017-04-06"),
           toDate = Some("2018-04-05"),
           None

--- a/test/models/PenaltyDetailsQueryParametersSpec.scala
+++ b/test/models/PenaltyDetailsQueryParametersSpec.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import base.SpecBase
+import models.PenaltyDetailsQueryParameters.dateLimitKey
+
+class PenaltyDetailsQueryParametersSpec extends SpecBase {
+
+  "The PenaltyDetailsQueryParameters object" should {
+
+    "have the correct key value for 'dateLimit'" in {
+      dateLimitKey shouldBe "dateLimit"
+    }
+  }
+
+  "The PenaltyDetailsQueryParameters.toSeqQueryParams method" should {
+
+    "output the expected sequence of key-value pairs" which {
+
+      "for no Query Parameters, has no values" in {
+        val queryParams = PenaltyDetailsQueryParameters()
+        queryParams.toSeqQueryParams shouldBe Seq()
+      }
+
+      "for the 'dateLimit' query param, has the expected key/value" in {
+        val queryParams = PenaltyDetailsQueryParameters(dateLimit = Some(1))
+        queryParams.toSeqQueryParams shouldBe Seq(dateLimitKey -> "1")
+      }
+    }
+  }
+}

--- a/test/services/API1166/FinancialTransactionsServiceSpec.scala
+++ b/test/services/API1166/FinancialTransactionsServiceSpec.scala
@@ -38,7 +38,7 @@ class FinancialTransactionsServiceSpec extends SpecBase with Mock1166FinancialDa
     "Return FinancialTransactions when a success response is returned from the Connector" in {
 
       val successResponse: Either[Nothing, FinancialTransactions] = Right(fullFinancialTransactions)
-      val queryParams: RequestQueryParameters = RequestQueryParameters(
+      val queryParams: FinancialRequestQueryParameters = FinancialRequestQueryParameters(
         fromDate = Some("2017-04-06"),
         toDate = Some("2018-04-05"),
         onlyOpenItems = Some(false)
@@ -50,7 +50,7 @@ class FinancialTransactionsServiceSpec extends SpecBase with Mock1166FinancialDa
 
       val actual: Either[ErrorResponse, FinancialTransactions] = await(TestFinancialTransactionService.getFinancialTransactions(
         regime,
-        RequestQueryParameters(
+        FinancialRequestQueryParameters(
           fromDate = Some("2017-04-06"),
           toDate = Some("2018-04-05"),
           onlyOpenItems = Some(false)
@@ -68,7 +68,7 @@ class FinancialTransactionsServiceSpec extends SpecBase with Mock1166FinancialDa
 
       val singleErrorResponse: Either[ErrorResponse, Nothing] = Left(ErrorResponse(Status.BAD_REQUEST, Error("CODE", "REASON")))
 
-      setupMockGetFinancialData(regime, RequestQueryParameters(
+      setupMockGetFinancialData(regime, FinancialRequestQueryParameters(
         fromDate = Some("2017-04-06"),
         toDate = Some("2018-04-05"),
         onlyOpenItems = Some(false)
@@ -76,7 +76,7 @@ class FinancialTransactionsServiceSpec extends SpecBase with Mock1166FinancialDa
 
       val actual: Either[ErrorResponse, FinancialTransactions] = await(TestFinancialTransactionService.getFinancialTransactions(
         regime,
-        RequestQueryParameters(
+        FinancialRequestQueryParameters(
           fromDate = Some("2017-04-06"),
           toDate = Some("2018-04-05"),
           onlyOpenItems = Some(false)
@@ -94,7 +94,7 @@ class FinancialTransactionsServiceSpec extends SpecBase with Mock1166FinancialDa
         Error("CODE 2", "REASON 2")
       ))))
 
-      setupMockGetFinancialData(regime, RequestQueryParameters(
+      setupMockGetFinancialData(regime, FinancialRequestQueryParameters(
         fromDate = Some("2017-04-06"),
         toDate = Some("2018-04-05"),
         onlyOpenItems = Some(false)
@@ -102,7 +102,7 @@ class FinancialTransactionsServiceSpec extends SpecBase with Mock1166FinancialDa
 
       val actual: Either[ErrorResponse, FinancialTransactions] = await(TestFinancialTransactionService.getFinancialTransactions(
         regime,
-        RequestQueryParameters(
+        FinancialRequestQueryParameters(
           fromDate = Some("2017-04-06"),
           toDate = Some("2018-04-05"),
           onlyOpenItems = Some(false)

--- a/test/services/API1811/FinancialTransactionsServiceSpec.scala
+++ b/test/services/API1811/FinancialTransactionsServiceSpec.scala
@@ -19,7 +19,7 @@ package services.API1811
 import base.SpecBase
 import mocks.connectors.Mock1811FinancialDataConnector
 import models.API1811.Error
-import models.{RequestQueryParameters, TaxRegime, VatRegime}
+import models.{FinancialRequestQueryParameters, TaxRegime, VatRegime}
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import utils.TestConstantsAPI1811.fullFinancialTransactions
 import utils.ImplicitDateFormatter._
@@ -31,7 +31,7 @@ class FinancialTransactionsServiceSpec extends SpecBase with Mock1811FinancialDa
 
   "The FinancialTransactionsService.getFinancialTransactions method" when {
 
-    val queryParams: RequestQueryParameters = RequestQueryParameters(
+    val queryParams: FinancialRequestQueryParameters = FinancialRequestQueryParameters(
       fromDate = Some("2017-04-06"),
       toDate = Some("2018-04-05"),
       onlyOpenItems = Some(false)


### PR DESCRIPTION
Also renamed the existing`RequestQueryParameters` to `FinancialRequestQueryParameters` for distinction from the new model.