### PR TITLE
[BTAT-10291] - Added document details block to financial details

### DIFF
--- a/app/models/API1811/DocumentDetails.scala
+++ b/app/models/API1811/DocumentDetails.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.API1811
+
+import java.time.LocalDate
+
+import play.api.libs.json.{Format, Json}
+
+case class DocumentDetails(
+                            taxYear: String,
+                            documentId: String,
+                            documentDate: LocalDate,
+                            documentText: String,
+                            documentDueDate: LocalDate,
+                            totalAmount: BigDecimal,
+                            documentOutstandingAmount: BigDecimal,
+                            accruingPenaltyLPP1: Option[String],
+                            lpp1Amount: Option[String],
+                            lpp1ID: Option[String],
+                            lpp2Amount: Option[String],
+                            accruingPenaltyLPP2: Option[String],
+                            lpp2ID: Option[String]
+                          )
+
+object DocumentDetails {
+  implicit val format: Format[DocumentDetails] = Json.format[DocumentDetails]
+}

--- a/app/models/API1811/DocumentDetails.scala
+++ b/app/models/API1811/DocumentDetails.scala
@@ -28,12 +28,9 @@ case class DocumentDetails(
                             documentDueDate: LocalDate,
                             totalAmount: BigDecimal,
                             documentOutstandingAmount: BigDecimal,
+                            statisticalFlag: Boolean,
                             accruingPenaltyLPP1: Option[String],
-                            lpp1Amount: Option[String],
-                            lpp1ID: Option[String],
-                            lpp2Amount: Option[String],
-                            accruingPenaltyLPP2: Option[String],
-                            lpp2ID: Option[String]
+                            accruingPenaltyLPP2: Option[String]
                           )
 
 object DocumentDetails {

--- a/test/models/API1811/DocumentDetailsSpec.scala
+++ b/test/models/API1811/DocumentDetailsSpec.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.API1811
+
+import play.api.libs.json.Json
+import utils.TestConstantsAPI1811._
+import base.SpecBase
+
+class DocumentDetailsSpec  extends SpecBase{
+
+  "DocumentDetails" should {
+    "serialize to Json successfully" in {
+      Json.toJson(fullDocumentDetails) shouldBe fullDocumentDetailsJson
+    }
+
+    "deserialize to a Transaction model successfully" in {
+      fullDocumentDetailsJson.as[DocumentDetails] shouldBe fullDocumentDetails
+    }
+  }
+
+}

--- a/test/utils/TestConstantsAPI1811.scala
+++ b/test/utils/TestConstantsAPI1811.scala
@@ -17,7 +17,7 @@
 package utils
 
 import play.api.libs.json.{JsObject, Json}
-import models.API1811.{FinancialTransactions, SubItem, Transaction}
+import models.API1811.{DocumentDetails, FinancialTransactions, SubItem, Transaction}
 import utils.ImplicitDateFormatter._
 import utils.TestConstants.fullTransactionJson
 
@@ -130,6 +130,38 @@ object TestConstantsAPI1811 {
 
   val fullFinancialTransactions: FinancialTransactions = FinancialTransactions(
     financialDetails = Seq(fullTransaction)
+  )
+
+  val fullDocumentDetails : DocumentDetails = DocumentDetails(
+    taxYear = "2017",
+    documentId = "1455",
+    documentDate = "2018-03-29",
+    documentText = "VAT-VC",
+    documentDueDate = "2020-04-15",
+    totalAmount = 45552768.79,
+    documentOutstandingAmount = 297873.46,
+    accruingPenaltyLPP1 = Some("1000.34"),
+    lpp1Amount = Some("1000.34"),
+    lpp1ID = Some("LPP1ID"),
+    accruingPenaltyLPP2 = Some("accrlpp2"),
+    lpp2Amount = Some("1000.34"),
+    lpp2ID = Some("LPP2ID")
+  )
+
+  val fullDocumentDetailsJson: JsObject = Json.obj(
+    "taxYear" -> "2017",
+    "documentId" -> "1455",
+    "documentDate" -> "2018-03-29",
+    "documentText" -> "VAT-VC",
+    "documentDueDate" -> "2020-04-15",
+    "totalAmount" -> 45552768.79,
+    "documentOutstandingAmount" -> 297873.46,
+    "accruingPenaltyLPP1" -> "1000.34",
+    "lpp1Amount" -> "1000.34",
+    "lpp1ID" -> "LPP1ID",
+    "accruingPenaltyLPP2" -> "accrlpp2",
+    "lpp2Amount" -> "1000.34",
+    "lpp2ID" -> "LPP2ID"
   )
 
 }

--- a/test/utils/TestConstantsAPI1811.scala
+++ b/test/utils/TestConstantsAPI1811.scala
@@ -140,12 +140,9 @@ object TestConstantsAPI1811 {
     documentDueDate = "2020-04-15",
     totalAmount = 45552768.79,
     documentOutstandingAmount = 297873.46,
+    statisticalFlag = false,
     accruingPenaltyLPP1 = Some("1000.34"),
-    lpp1Amount = Some("1000.34"),
-    lpp1ID = Some("LPP1ID"),
-    accruingPenaltyLPP2 = Some("accrlpp2"),
-    lpp2Amount = Some("1000.34"),
-    lpp2ID = Some("LPP2ID")
+    accruingPenaltyLPP2 = Some("accrlpp2")
   )
 
   val fullDocumentDetailsJson: JsObject = Json.obj(
@@ -156,12 +153,9 @@ object TestConstantsAPI1811 {
     "documentDueDate" -> "2020-04-15",
     "totalAmount" -> 45552768.79,
     "documentOutstandingAmount" -> 297873.46,
+    "statisticalFlag" -> false,
     "accruingPenaltyLPP1" -> "1000.34",
-    "lpp1Amount" -> "1000.34",
-    "lpp1ID" -> "LPP1ID",
     "accruingPenaltyLPP2" -> "accrlpp2",
-    "lpp2Amount" -> "1000.34",
-    "lpp2ID" -> "LPP2ID"
   )
 
 }


### PR DESCRIPTION
Due to Scala not allowing more than 22 parameters in a case class. I have not included all the fields from the spec, instead I have kept the mandatory fields needed and what I think is need in regards to the WYO mapping document. To whoever picks this up, would you mind triple checking that I have removed the correct fields and included the right ones from the mapping document. Thanks 😄 