### PR TITLE
BTAT-11001 Add JSON writes for API 1811 output

### DIFF
--- a/app/connectors/API1811/FinancialDataConnector.scala
+++ b/app/connectors/API1811/FinancialDataConnector.scala
@@ -34,7 +34,7 @@ class FinancialDataConnector @Inject()(http: HttpClient, httpParser: FinancialTr
     s"${appConfig.eisUrl}/penalty/financial-data/${regime.idType}/${regime.id}/${regime.regimeType}"
 
   def getFinancialData(regime: TaxRegime, queryParameters: FinancialRequestQueryParameters)
-                      (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[FinancialTransactionsResponse] = {
+                      (implicit headerCarrier: HeaderCarrier, ec: ExecutionContext): Future[FinancialTransactionsResponse] = {
 
     val eisHeaders = Seq(
       "Authorization" -> s"Bearer ${appConfig.eisToken}",
@@ -42,6 +42,7 @@ class FinancialDataConnector @Inject()(http: HttpClient, httpParser: FinancialTr
       "Environment" -> appConfig.eisEnvironment
     )
 
+    val hc = headerCarrier.copy(authorization = None)
     val url = financialDataUrl(regime)
 
     logger.debug("[FinancialDataConnector][getFinancialData] - " +

--- a/app/connectors/API1812/PenaltyDetailsConnector.scala
+++ b/app/connectors/API1812/PenaltyDetailsConnector.scala
@@ -33,13 +33,19 @@ class PenaltyDetailsConnector @Inject()(val http: HttpClient, val appConfig: Mic
     s"${appConfig.eisUrl}/penalty/details/${regime.regimeType}/${regime.idType}/${regime.id}"
 
   def getPenaltyDetails(regime: TaxRegime, queryParameters: PenaltyDetailsQueryParameters)
-                      (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[PenaltyDetailsResponse] = {
+                       (implicit headerCarrier: HeaderCarrier, ec: ExecutionContext): Future[PenaltyDetailsResponse] = {
 
-    val eisHeaders = Seq("Authorization" -> s"Bearer ${appConfig.eisToken}","CorrelationId" -> randomUUID().toString, "Environment" -> appConfig.eisEnvironment)
+    val eisHeaders = Seq(
+      "Authorization" -> s"Bearer ${appConfig.eisToken}",
+      "CorrelationId" -> randomUUID().toString,
+      "Environment" -> appConfig.eisEnvironment
+    )
 
+    val hc = headerCarrier.copy(authorization = None)
     val url = penaltyDetailsUrl(regime)
 
-    logger.debug(s"[PenaltyDetailsConnector][getPenaltyDetails] - Calling GET $url \nHeaders: $eisHeaders\n QueryParams: $queryParameters")
+    logger.debug("[PenaltyDetailsConnector][getPenaltyDetails] - " +
+      s"Calling GET $url \nHeaders: $eisHeaders\n QueryParams: $queryParameters")
     http.GET[PenaltyDetailsResponse](url, queryParameters.toSeqQueryParams, eisHeaders)(PenaltyDetailsReads,hc, ec)
   }
 }

--- a/app/controllers/FinancialTransactionsController.scala
+++ b/app/controllers/FinancialTransactionsController.scala
@@ -82,8 +82,13 @@ class FinancialTransactionsController @Inject()(authenticate: AuthAction,
       "Calling API1811.FinancialTransactionsService.getFinancialTransactions")
 
     api1811Service.getFinancialTransactions(regime, queryParams).map {
-      case Right(financialTransactions) => Ok(Json.obj()) // TODO put the transactions back in once Writes exists again
+      case Right(financialTransactions) => Ok(Json.toJson(financialTransactions))
       case Left(error) => Status(error.code)(Json.toJson(error))
+    }.recover {
+      case ex =>
+        logger.warn("[FinancialTransactionsController][retrieveFinancialTransactionsAPI1811] - " +
+          s"Exception received when retrieving data: ${ex.getMessage}, returning status code 500")
+        InternalServerError(Json.toJson(API1811.Error(INTERNAL_SERVER_ERROR, ex.getMessage)))
     }
   }
 

--- a/app/controllers/actions/AuthAction.scala
+++ b/app/controllers/actions/AuthAction.scala
@@ -52,8 +52,8 @@ class AuthActionImpl @Inject()(val authorisedFunctions: AuthorisedFunctions, cc:
       case _: NoActiveSession =>
         logger.debug("[AuthActionImpl][invokeBlock] Request did not have an Active Session, returning Unauthorised - Unauthenticated Error")
         Unauthorized(Json.toJson(UnauthenticatedError))
-      case _ =>
-        logger.debug("[AuthActionImpl][invokeBlock] Request has an active session but was not authorised, returning Forbidden - Not Authorised Error")
+      case ex =>
+        logger.debug(s"[AuthActionImpl][invokeBlock] - Unexpected exception ${ex.getMessage}, returning Forbidden - Not Authorised Error")
         Forbidden(Json.toJson(ForbiddenError))
     }
   }

--- a/app/models/API1811/FinancialTransactions.scala
+++ b/app/models/API1811/FinancialTransactions.scala
@@ -16,6 +16,7 @@
 
 package models.API1811
 
+import config.AppConfig
 import play.api.libs.json._
 
 case class FinancialTransactions(documentDetails: Seq[DocumentDetails])
@@ -25,4 +26,8 @@ object FinancialTransactions {
   implicit val reads: Reads[FinancialTransactions] =
     (__ \ "getFinancialData" \ "financialDetails" \ "documentDetails").read[Seq[DocumentDetails]]
       .map(FinancialTransactions.apply)
+
+  implicit def writes(implicit appConfig: AppConfig): Writes[FinancialTransactions] = Writes { model =>
+    Json.obj("financialTransactions" -> Json.toJsFieldJsValueWrapper(model.documentDetails))
+  }
 }

--- a/app/models/API1811/LineItemDetails.scala
+++ b/app/models/API1811/LineItemDetails.scala
@@ -18,10 +18,8 @@ package models.API1811
 
 import java.time.LocalDate
 
-import config.AppConfig
 import play.api.libs.functional.syntax.toFunctionalBuilderOps
 import play.api.libs.json._
-import utils.API1811.ChargeTypes
 
 case class LineItemDetails(mainTransaction: Option[String],
                            subTransaction: Option[String],
@@ -53,9 +51,14 @@ object LineItemDetails {
     (JsPath \ "lineItemInterestDetails" \"currentInterestRate").readNullable[BigDecimal]
   ) (LineItemDetails.apply _)
 
-  implicit def writes(implicit appConfig: AppConfig): Writes[LineItemDetails] = Writes { model =>
+  implicit val writes: Writes[LineItemDetails] = Writes { model =>
     JsObject(Json.obj(
-      "chargeType" -> ChargeTypes.retrieveChargeType(model.mainTransaction, model.subTransaction)
+      "dueDate" -> model.netDueDate,
+      "amount" -> model.amount,
+      "clearingDate" -> model.clearingDate,
+      "clearingReason" -> model.clearingReason,
+      "clearingSAPDocument" -> model.clearingDocument,
+      "DDcollectionInProgress" -> model.ddCollectionInProgress
     ).fields.filterNot(_._2 == JsNull))
   }
 }

--- a/it/controllers/FinancialTransactionsComponentSpec.scala
+++ b/it/controllers/FinancialTransactionsComponentSpec.scala
@@ -52,7 +52,7 @@ class FinancialTransactionsComponentSpec extends ComponentSpecBase {
         Then("a successful response is returned with expected JSON data")
         res should have(
           httpStatus(OK),
-          jsonBodyAs(Json.obj())
+          jsonBodyAs(FinancialData1811.fullFinancialTransactionsOutputJson)
         )
       }
     }

--- a/it/testData/FinancialData1811.scala
+++ b/it/testData/FinancialData1811.scala
@@ -70,7 +70,7 @@ object FinancialData1811 {
           ),
           "documentPenaltyTotals" -> Json.arr(Json.obj(
             "penaltyType" -> "LPP1",
-            "penaltyStatus" -> "POSTED",
+            "penaltyStatus" -> "ACCRUING",
             "penaltyAmount" -> "10.01",
             "postedChargeReference" -> "XR00123933492"
           )),
@@ -133,7 +133,7 @@ object FinancialData1811 {
       lineItemDetails = Seq(lineItems),
       interestAccruingAmount = Some(12.10),
       penaltyType = Some("LPP1"),
-      penaltyStatus = Some("POSTED"),
+      penaltyStatus = Some("ACCRUING"),
       penaltyAmount = Some(10.01)
     ))
   )
@@ -147,4 +147,29 @@ object FinancialData1811 {
 
   val errorModel: Error = Error(Status.BAD_REQUEST, errorJson.toString())
 
+  val fullFinancialTransactionsOutputJson: JsObject = Json.obj(
+    "financialTransactions" -> Json.arr(Json.obj(
+      "chargeType" -> "VAT Return Debit Charge",
+      "periodKey" -> "22A1",
+      "taxPeriodFrom" -> "2022-01-01",
+      "taxPeriodTo" -> "2022-01-31",
+      "chargeReference" -> "XP001286394838",
+      "mainTransaction" -> "4700",
+      "subTransaction" -> "1174",
+      "originalAmount" -> 100.00,
+      "outstandingAmount" -> 0.00,
+      "items" -> Json.arr(Json.obj(
+        "dueDate" -> "2022-02-08",
+        "amount" -> 3420.00,
+        "clearingDate" -> "2022-02-09",
+        "clearingReason" -> "Payment at External Payment Collector Reported",
+        "clearingSAPDocument" -> "719283701921",
+        "DDcollectionInProgress" -> true
+      )),
+      "accruingInterestAmount" -> 12.10,
+      "interestRate" -> -999.99,
+      "accruingPenaltyAmount" -> 10.01,
+      "penaltyType" -> "LPP1"
+    ))
+  )
 }

--- a/test/connectors/API1811/httpParsers/FinancialTransactionsHttpParserSpec.scala
+++ b/test/connectors/API1811/httpParsers/FinancialTransactionsHttpParserSpec.scala
@@ -49,9 +49,7 @@ class FinancialTransactionsHttpParserSpec extends SpecBase {
 
         val httpResponse = HttpResponse(Status.OK, filteredFinancialJson.toString)
 
-        val expected = Right(fullFinancialTransactions.copy(
-          documentDetails = Seq(fullDocumentDetails.copy(lineItemDetails = Seq()))
-        ))
+        val expected = Right(fullFinancialTransactions.copy(documentDetails = Seq()))
 
         val result = httpParser.FinancialTransactionsReads.read("", "", httpResponse)
 

--- a/test/mocks/services/Mock1811FinancialTransactionsService.scala
+++ b/test/mocks/services/Mock1811FinancialTransactionsService.scala
@@ -31,12 +31,11 @@ trait Mock1811FinancialTransactionsService {
   val mock1811FinancialTransactionsService: api1811FinancialTransactionsService = mock[api1811FinancialTransactionsService]
 
   def setupMock1811GetFinancialTransactions(regime: TaxRegime, queryParameters: FinancialRequestQueryParameters)
-                                       (response: FinancialTransactionsResponse): OngoingStubbing[Future[FinancialTransactionsResponse]] =
+                                       (response: Future[FinancialTransactionsResponse]): OngoingStubbing[Future[FinancialTransactionsResponse]] =
     when(
       mock1811FinancialTransactionsService.getFinancialTransactions(
         ArgumentMatchers.eq(regime),
         ArgumentMatchers.eq(queryParameters)
       )(ArgumentMatchers.any())
-    ).thenReturn(Future.successful(response))
-
+    ).thenReturn(response)
 }

--- a/test/models/API1811/FinancialTransactionsSpec.scala
+++ b/test/models/API1811/FinancialTransactionsSpec.scala
@@ -17,14 +17,34 @@
 package models.API1811
 
 import base.SpecBase
+import play.api.libs.json.Json
 import utils.API1811.TestConstants._
 
 class FinancialTransactionsSpec extends SpecBase {
 
   "FinancialTransactions" should {
 
-    "deserialize to a Transaction model successfully" in {
-      fullFinancialTransactionsJsonEIS.as[FinancialTransactions] shouldBe fullFinancialTransactions
+    "read from JSON" when {
+
+      "maximum fields are present" in {
+        fullFinancialTransactionsJsonEIS.as[FinancialTransactions] shouldBe fullFinancialTransactions
+      }
+    }
+
+    "write to JSON" when {
+
+      "maximum fields are present" in {
+        Json.toJson(fullFinancialTransactions) shouldBe fullFinancialTransactionsOutputJson
+      }
+
+      "there are multiple document details objects" in {
+        val model = FinancialTransactions(Seq(fullDocumentDetails, fullDocumentDetails))
+        val expectedOutput = Json.obj(
+          "financialTransactions" -> Json.arr(fullDocumentDetailsOutputJson, fullDocumentDetailsOutputJson)
+        )
+
+        Json.toJson(model) shouldBe expectedOutput
+      }
     }
   }
 }

--- a/test/models/API1811/LineItemDetailsSpec.scala
+++ b/test/models/API1811/LineItemDetailsSpec.scala
@@ -22,53 +22,31 @@ import utils.API1811.TestConstants._
 
 class LineItemDetailsSpec extends SpecBase {
 
-  "LineItemDetails" when {
+  "LineItemDetails" should {
 
-    "maximum fields are present" should {
+    "read from JSON" when {
 
-      "deserialise from JSON correctly" in {
+      "maximum fields are present" in {
         lineItemDetailsFullJson.as[LineItemDetails] shouldBe lineItemDetailsFull
       }
-    }
 
-    "minimum fields are present" should {
-
-      "deserialise from JSON correctly" in {
-        val emptyModel = LineItemDetails(None, None, None, None, None, None, None, None, None, None, None, None)
-        Json.obj("" -> "").as[LineItemDetails] shouldBe emptyModel
+      "minimum fields are present" in {
+        Json.obj("" -> "").as[LineItemDetails] shouldBe emptyLineItem
       }
-    }
 
-    "some correct fields are present but some are unrecognised" should {
-
-      "read the recognised fields correctly" in {
+      "some correct fields are present but some are unrecognised" in {
         lineItemDetailsFullIncorrectFieldsJson.as[LineItemDetails] shouldBe lineItemDetailsFullIncorrectFields
       }
     }
 
-  }
+    "write to JSON" when {
 
-  "LineItemDetails json writes" should {
-
-    "write a LineItemDetails model to maximum JSON successfully" when {
-
-      "all fields are present" in {
-        Json.toJson(lineItemDetailsFull) shouldBe Json.obj("chargeType" -> "VAT Return Debit Charge")
-      }
-    }
-
-    "not include a chargeType field in the output JSON" should {
-
-      "main transaction is not present" in {
-        Json.toJson(lineItemDetailsFull.copy(mainTransaction = None)) shouldBe Json.obj()
+      "maximum fields are present" in {
+        Json.toJson(lineItemDetailsFull) shouldBe fullLineItemDetailsOutputJson
       }
 
-      "sub transaction is not present" in {
-        Json.toJson(lineItemDetailsFull.copy(subTransaction = None)) shouldBe Json.obj()
-      }
-
-      "main transaction and sub transaction are not present" in {
-        Json.toJson(lineItemDetailsFull.copy(mainTransaction = None, subTransaction = None)) shouldBe Json.obj()
+      "minimum fields are present" in {
+        Json.toJson(emptyLineItem) shouldBe Json.obj()
       }
     }
   }

--- a/test/utils/API1811/ChargeTypesSpec.scala
+++ b/test/utils/API1811/ChargeTypesSpec.scala
@@ -30,7 +30,7 @@ class ChargeTypesSpec extends SpecBase {
       "return a list of charge types excluding those associated with the penalties and interest work package" in {
         mockAppConfig.features.includePenAndIntCharges(false)
         val list = ChargeTypes.supportedChargeList
-        list.size shouldBe 53
+        list.size shouldBe 55
         list.get(vatReturnLPITransaction) shouldBe None
       }
     }
@@ -40,7 +40,7 @@ class ChargeTypesSpec extends SpecBase {
       "return a list of all recognised charge types" in {
         mockAppConfig.features.includePenAndIntCharges(true)
         val list = ChargeTypes.supportedChargeList
-        list.size shouldBe 84
+        list.size shouldBe 86
         list.get(vatReturnLPITransaction) shouldBe Some("VAT Return LPI")
       }
     }
@@ -76,49 +76,44 @@ class ChargeTypesSpec extends SpecBase {
     "filter out charges" when {
 
       "the main transaction value is not supported" in {
-        val transactions = Seq(lineItemDetailsFull, lineItemDetailsFull.copy(mainTransaction = Some("1111")))
-        val dDetails = Seq(fullDocumentDetails.copy(lineItemDetails = transactions))
-        val expected = Seq(fullDocumentDetails.copy(lineItemDetails = Seq(lineItemDetailsFull)))
-        ChargeTypes.removeInvalidCharges(dDetails) shouldBe expected
+        val lineItems = Seq(lineItemDetailsFull.copy(mainTransaction = Some("1111")))
+        val dDetails = Seq(fullDocumentDetails.copy(lineItemDetails = lineItems))
+        ChargeTypes.removeInvalidCharges(dDetails) shouldBe Seq()
       }
 
       "the sub transaction value is not supported" in {
-        val transactions = Seq(lineItemDetailsFull, lineItemDetailsFull.copy(subTransaction = Some("1111")))
-        val dDetails = Seq(fullDocumentDetails.copy(lineItemDetails = transactions))
-        val expected = Seq(fullDocumentDetails.copy(lineItemDetails = Seq(lineItemDetailsFull)))
-        ChargeTypes.removeInvalidCharges(dDetails) shouldBe expected
+        val lineItems = Seq(lineItemDetailsFull.copy(subTransaction = Some("1111")))
+        val dDetails = Seq(fullDocumentDetails.copy(lineItemDetails = lineItems))
+        ChargeTypes.removeInvalidCharges(dDetails) shouldBe Seq()
       }
 
       "the main transaction value is not present" in {
-        val transactions = Seq(lineItemDetailsFull, lineItemDetailsFull.copy(mainTransaction = None))
-        val dDetails = Seq(fullDocumentDetails.copy(lineItemDetails = transactions))
-        val expected = Seq(fullDocumentDetails.copy(lineItemDetails = Seq(lineItemDetailsFull)))
-        ChargeTypes.removeInvalidCharges(dDetails) shouldBe expected
+        val lineItems = Seq(lineItemDetailsFull.copy(mainTransaction = None))
+        val dDetails = Seq(fullDocumentDetails.copy(lineItemDetails = lineItems))
+        ChargeTypes.removeInvalidCharges(dDetails) shouldBe Seq()
       }
 
       "the sub transaction value is not present" in {
-        val transactions = Seq(lineItemDetailsFull, lineItemDetailsFull.copy(subTransaction = None))
-        val dDetails = Seq(fullDocumentDetails.copy(lineItemDetails = transactions))
-        val expected = Seq(fullDocumentDetails.copy(lineItemDetails = Seq(lineItemDetailsFull)))
-        ChargeTypes.removeInvalidCharges(dDetails) shouldBe expected
+        val lineItems = Seq(lineItemDetailsFull.copy(subTransaction = None))
+        val dDetails = Seq(fullDocumentDetails.copy(lineItemDetails = lineItems))
+        ChargeTypes.removeInvalidCharges(dDetails) shouldBe Seq()
       }
 
-      "the documentDetails has no lineItemDetails" in {
-        val dDetails = Seq(fullDocumentDetails.copy(lineItemDetails = Seq()))
-        ChargeTypes.removeInvalidCharges(dDetails) shouldBe dDetails
+      "there are multiple lineItemDetails and only one of them has invalid transaction values" in {
+        val lineItems = Seq(lineItemDetailsFull, lineItemDetailsFull.copy(subTransaction = Some("1111")))
+        val dDetails = Seq(fullDocumentDetails.copy(lineItemDetails = lineItems))
+        ChargeTypes.removeInvalidCharges(dDetails) shouldBe Seq()
       }
     }
 
     val vatReturnLPITransaction = lineItemDetailsFull.copy(mainTransaction = Some("4620"), subTransaction = Some("1175"))
-    val transactions = Seq(lineItemDetailsFull, vatReturnLPITransaction)
-    val dDetails = Seq(fullDocumentDetails.copy(lineItemDetails = transactions))
+    val dDetails = Seq(fullDocumentDetails, fullDocumentDetails.copy(lineItemDetails = Seq(vatReturnLPITransaction)))
 
     "filter out penalties and interest charges" when {
 
       "the includePenAndIntCharges feature switch is off" in {
         mockAppConfig.features.includePenAndIntCharges(false)
-        val expected = Seq(fullDocumentDetails.copy(lineItemDetails = Seq(lineItemDetailsFull)))
-        ChargeTypes.removeInvalidCharges(dDetails) shouldBe expected
+        ChargeTypes.removeInvalidCharges(dDetails) shouldBe Seq(fullDocumentDetails)
       }
     }
 

--- a/test/utils/API1811/TestConstants.scala
+++ b/test/utils/API1811/TestConstants.scala
@@ -97,7 +97,7 @@ object TestConstants {
     lineItemDetails = Seq(lineItemDetailsFull),
     interestAccruingAmount = Some(0.23),
     penaltyType = Some("LPP1"),
-    penaltyStatus = Some("POSTED"),
+    penaltyStatus = Some("ACCRUING"),
     penaltyAmount = Some(10.01)
   )
 
@@ -111,7 +111,7 @@ object TestConstants {
     ),
     "documentPenaltyTotals" -> Json.arr(Json.obj(
       "penaltyType" -> "LPP1",
-      "penaltyStatus" -> "POSTED",
+      "penaltyStatus" -> "ACCRUING",
       "penaltyAmount" -> 10.01
     ))
   )
@@ -126,7 +126,7 @@ object TestConstants {
     ),
     "documentPenaltyTotals" -> Json.arr(Json.obj(
       "penaltyType" -> "LPP1",
-      "penaltyStatus" -> "POSTED",
+      "penaltyStatus" -> "ACCRUING",
       "penaltyAmount" -> 10.01
     ))
   )
@@ -141,7 +141,7 @@ object TestConstants {
     ),
     "documentPenaltyTotals" -> Json.arr(Json.obj(
       "penaltyType" -> "LPP1",
-      "penaltyStatus" -> "POSTED",
+      "penaltyStatus" -> "ACCRUING",
       "penaltyAmount" -> 10.01
     ))
   )
@@ -152,7 +152,7 @@ object TestConstants {
   )
 
   val emptyLineItem: LineItemDetails = LineItemDetails(None, None, None, None, None, None, None, None, None, None, None, None)
-  val emptyModel: DocumentDetails = DocumentDetails(None, None, None, Seq(emptyLineItem), None, None, None, None)
+  val emptyDocumentDetails: DocumentDetails = DocumentDetails(None, None, None, Seq(emptyLineItem), None, None, None, None)
 
   def fullFTJson(documentDetails: JsObject): JsObject = Json.obj(
     "getFinancialData" -> Json.obj(
@@ -168,4 +168,33 @@ object TestConstants {
     documentDetails = Seq(fullDocumentDetails)
   )
 
+  val fullLineItemDetailsOutputJson: JsObject = Json.obj(
+    "dueDate" -> "2018-02-14",
+    "amount" -> 3400,
+    "clearingDate" -> "2017-08-06",
+    "clearingReason" -> "Payment at External Payment Collector Reported",
+    "clearingSAPDocument" -> "719283701921",
+    "DDcollectionInProgress" -> true
+  )
+
+  val fullDocumentDetailsOutputJson: JsObject = Json.obj(
+    "chargeType" -> "VAT Return Debit Charge",
+    "periodKey" -> "13RL",
+    "taxPeriodFrom" -> "2017-04-06",
+    "taxPeriodTo" -> "2018-04-05",
+    "chargeReference" -> "XM002610011594",
+    "mainTransaction" -> "4700",
+    "subTransaction" -> "1174",
+    "originalAmount" -> 45552768.79,
+    "outstandingAmount" -> 297873.46,
+    "items" -> Json.arr(fullLineItemDetailsOutputJson),
+    "accruingInterestAmount" -> 0.23,
+    "interestRate" -> 3,
+    "accruingPenaltyAmount" -> 10.01,
+    "penaltyType" -> "LPP1"
+  )
+
+  val fullFinancialTransactionsOutputJson: JsObject = Json.obj(
+    "financialTransactions" -> Json.arr(fullDocumentDetailsOutputJson)
+  )
 }


### PR DESCRIPTION
Had to address a few bugs:
- Removed duplicate authorization header from API#1811 and 1812 connectors
- Adjusted "invalid charge type" filtering so that it removes the whole document rather than just a line item
- Added two missing migrated charge types into 1811 charge type list

I did a bit of manual testing where I toggled the API switch on and went into the frontend with users 5 and 6.