### PR TITLE
BTAT-11051 Updated contract test components to send query string params

### DIFF
--- a/app/testOnly/connectors/ContractTestConnector.scala
+++ b/app/testOnly/connectors/ContractTestConnector.scala
@@ -35,7 +35,8 @@ class ContractTestConnector @Inject()(implicit appConfig: MicroserviceAppConfig)
   val host: String =
     if(appConfig.eisUrl.contains("localhost")) "https://admin.qa.tax.service.gov.uk/ifs" else appConfig.eisUrl
 
-  def callAPI(url: String)(implicit request: Request[_]): Future[StandaloneWSResponse] = {
+  def callAPI(url: String, queryStringParameters: Seq[(String, String)])
+             (implicit request: Request[_]): Future[StandaloneWSResponse] = {
 
     val apiUrl = host + url
     val headers: Seq[(String, String)] = if(request.headers.headers.exists(_._1 == "Authorization")) {
@@ -44,8 +45,8 @@ class ContractTestConnector @Inject()(implicit appConfig: MicroserviceAppConfig)
       Seq("Authorization" -> appConfig.eisToken) ++ request.headers.headers
     }
 
-    logger.debug(s"[ContractTestConnector][callAPI] - Calling URL: $apiUrl")
+    logger.debug(s"[ContractTestConnector][callAPI] - Calling URL: $apiUrl with query params: $queryStringParameters")
 
-    wsClient.url(apiUrl).addHttpHeaders(headers:_*).get()
+    wsClient.url(apiUrl).withQueryStringParameters(queryStringParameters:_*).withHttpHeaders(headers:_*).get()
   }
 }

--- a/app/testOnly/controllers/ContractTestController.scala
+++ b/app/testOnly/controllers/ContractTestController.scala
@@ -29,8 +29,16 @@ class ContractTestController @Inject()(connector: ContractTestConnector,
                                       (implicit ec: ExecutionContext) extends BackendController(cc) {
 
   def callAPI(url: String): Action[AnyContent] = Action.async { implicit request =>
-    val modifiedUrl = request.uri.replace("/financial-transactions/test-only", "")
-    connector.callAPI(modifiedUrl).map { result =>
+    val urlSplit = request.uri.replace("/financial-transactions/test-only", "").split('?')
+
+    val url = urlSplit(0)
+    val queryParams = if(urlSplit.length > 1) {
+      urlSplit(1).split('&').map(param => (param.split('=')(0), param.split('=')(1))).toSeq
+    } else {
+      Seq()
+    }
+
+    connector.callAPI(url, queryParams).map { result =>
       Status(result.status)(result.body)
     }
   }


### PR DESCRIPTION
I'm using https://www.playframework.com/documentation/2.8.x/ScalaWS as reference for using query string and header functions