### PR TITLE
BTAT-11051 Re-ordered test-only routes priority

### DIFF
--- a/app/testOnly/connectors/ContractTestConnector.scala
+++ b/app/testOnly/connectors/ContractTestConnector.scala
@@ -45,7 +45,8 @@ class ContractTestConnector @Inject()(implicit appConfig: MicroserviceAppConfig)
       Seq("Authorization" -> appConfig.eisToken) ++ request.headers.headers
     }
 
-    logger.debug(s"[ContractTestConnector][callAPI] - Calling URL: $apiUrl with query params: $queryStringParameters")
+    logger.debug("[ContractTestConnector][callAPI] - " +
+     s"Calling URL: $apiUrl\nQuery params: $queryStringParameters\nHeaders: $headers")
 
     wsClient.url(apiUrl).withQueryStringParameters(queryStringParameters:_*).withHttpHeaders(headers:_*).get()
   }

--- a/app/testOnly/controllers/ContractTestController.scala
+++ b/app/testOnly/controllers/ContractTestController.scala
@@ -19,6 +19,7 @@ package testOnly.controllers
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import testOnly.connectors.ContractTestConnector
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
+import utils.LoggerUtil
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.ExecutionContext
@@ -26,7 +27,7 @@ import scala.concurrent.ExecutionContext
 @Singleton
 class ContractTestController @Inject()(connector: ContractTestConnector,
                                        cc: ControllerComponents)
-                                      (implicit ec: ExecutionContext) extends BackendController(cc) {
+                                      (implicit ec: ExecutionContext) extends BackendController(cc) with LoggerUtil {
 
   def callAPI(url: String): Action[AnyContent] = Action.async { implicit request =>
     val urlSplit = request.uri.replace("/financial-transactions/test-only", "").split('?')
@@ -39,6 +40,7 @@ class ContractTestController @Inject()(connector: ContractTestConnector,
     }
 
     connector.callAPI(url, queryParams).map { result =>
+      logger.debug(s"[ContractTestController][callAPI] - Response body received: ${result.body}")
       Status(result.status)(result.body)
     }
   }

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -10,6 +10,6 @@
 # Failing to follow this rule may result in test routes deployed in production.
 
 # Add all the application routes to the prod.routes file
-->         /                                              prod.Routes
-
 GET        /financial-transactions/test-only/*url         testOnly.controllers.ContractTestController.callAPI(url: String)
+
+->         /                                              prod.Routes


### PR DESCRIPTION
Due to app.routes already having a "wildcard" type of route that was taking priority over this