### PR TITLE
BTAT-11051 Refactor to ContractTestConnector to use HttpClient

### DIFF
--- a/app/testOnly/models/APIResponseModel.scala
+++ b/app/testOnly/models/APIResponseModel.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testOnly.models
+
+import uk.gov.hmrc.http.{HttpReads, HttpResponse}
+
+case class APIResponseModel(status: Int, body: String)
+
+object APIResponseModel {
+  implicit object APIResponseModelReads extends HttpReads[APIResponseModel] {
+    override def read(method: String, url: String, response: HttpResponse): APIResponseModel =
+      APIResponseModel(response.status, response.body)
+  }
+}


### PR DESCRIPTION
Using WS client to make the call looks to be getting a 400 error from Nginx before reaching the API.
Using HttpClient makes this more in line with our other connectors.