### PR TITLE
BTAT-11185 Added functionality to write TTP boolean

### DIFF
--- a/app/models/API1811/LineItemDetails.scala
+++ b/app/models/API1811/LineItemDetails.scala
@@ -32,7 +32,8 @@ case class LineItemDetails(mainTransaction: Option[String],
                            clearingDate: Option[LocalDate],
                            clearingReason: Option[String],
                            clearingDocument: Option[String],
-                           interestRate: Option[BigDecimal])
+                           interestRate: Option[BigDecimal],
+                           lineItemLockDetails: Seq[LineItemLockDetails])
 
 object LineItemDetails {
 
@@ -48,7 +49,8 @@ object LineItemDetails {
     (JsPath \ "clearingDate").readNullable[LocalDate] and
     (JsPath \ "clearingReason").readNullable[String] and
     (JsPath \ "clearingDocument").readNullable[String] and
-    (JsPath \ "lineItemInterestDetails" \"currentInterestRate").readNullable[BigDecimal]
+    (JsPath \ "lineItemInterestDetails" \ "currentInterestRate").readNullable[BigDecimal] and
+    (JsPath \ "lineItemLockDetails").read[Seq[LineItemLockDetails]].orElse(Reads.pure(Seq.empty))
   ) (LineItemDetails.apply _)
 
   implicit val writes: Writes[LineItemDetails] = Writes { model =>

--- a/app/models/API1811/LineItemLockDetails.scala
+++ b/app/models/API1811/LineItemLockDetails.scala
@@ -14,18 +14,12 @@
  * limitations under the License.
  */
 
-package services
+package models.API1811
 
-import java.time.LocalDate
+import play.api.libs.json.{Json, Reads}
 
-object DateService {
+case class LineItemLockDetails(lockType: String)
 
-  def now(implicit appConfig: config.AppConfig): LocalDate = {
-    if (appConfig.features.staticDate()) {
-      LocalDate.parse(appConfig.staticDateValue)
-    } else {
-      LocalDate.now()
-    }
-  }
-
+object LineItemLockDetails {
+  implicit val reads: Reads[LineItemLockDetails] = Json.reads[LineItemLockDetails]
 }

--- a/it/testData/FinancialData1811.scala
+++ b/it/testData/FinancialData1811.scala
@@ -15,7 +15,7 @@
  */
 package testData
 
-import models.API1811.{DocumentDetails, Error, FinancialTransactions, LineItemDetails}
+import models.API1811.{DocumentDetails, Error, FinancialTransactions, LineItemDetails, LineItemLockDetails}
 import play.api.libs.json.{JsObject, Json}
 import play.api.http.Status
 
@@ -94,7 +94,7 @@ object FinancialData1811 {
             "outgoingPaymentMethod" -> "B",
             "ddCollectionInProgress" -> true,
             "lineItemLockDetails" -> Json.arr(Json.obj(
-              "lockType" -> "Payment",
+              "lockType" -> "Some payment lock",
               "lockStartDate" -> "2022-01-01",
               "lockEndDate" -> "2022-01-01"
             )),
@@ -123,7 +123,8 @@ object FinancialData1811 {
     clearingDate = Some(LocalDate.parse("2022-02-09")),
     clearingReason = Some("Payment at External Payment Collector Reported"),
     clearingDocument = Some("719283701921"),
-    interestRate = Some(-999.99)
+    interestRate = Some(-999.99),
+    lineItemLockDetails = Seq(LineItemLockDetails("Some payment lock"))
   )
 
   val fullFinancialTransactions: FinancialTransactions = FinancialTransactions(Seq(
@@ -173,6 +174,7 @@ object FinancialData1811 {
       "interestRate" -> -999.99,
       "accruingPenaltyAmount" -> 10.01,
       "penaltyType" -> "LPP1"
-    ))
+    )),
+    "hasOverdueChargeAndNoTTP" -> false
   )
 }

--- a/test/models/API1811/FinancialTransactionsSpec.scala
+++ b/test/models/API1811/FinancialTransactionsSpec.scala
@@ -17,10 +17,15 @@
 package models.API1811
 
 import base.SpecBase
+import org.scalatest.BeforeAndAfterAll
 import play.api.libs.json.Json
 import utils.API1811.TestConstants._
 
-class FinancialTransactionsSpec extends SpecBase {
+import java.time.LocalDate
+
+class FinancialTransactionsSpec extends SpecBase with BeforeAndAfterAll {
+
+  override def beforeAll(): Unit = mockAppConfig.features.staticDate(true)
 
   "FinancialTransactions" should {
 
@@ -40,10 +45,75 @@ class FinancialTransactionsSpec extends SpecBase {
       "there are multiple document details objects" in {
         val model = FinancialTransactions(Seq(fullDocumentDetails, fullDocumentDetails))
         val expectedOutput = Json.obj(
-          "financialTransactions" -> Json.arr(fullDocumentDetailsOutputJson, fullDocumentDetailsOutputJson)
+          "financialTransactions" -> Json.arr(fullDocumentDetailsOutputJson, fullDocumentDetailsOutputJson),
+          "hasOverdueChargeAndNoTTP" -> true
         )
 
         Json.toJson(model) shouldBe expectedOutput
+      }
+    }
+  }
+
+  "The hasOverdueChargeAndNoTTP function" should {
+
+    def generateDocDetails(dueDate: String, lockDetails: Seq[LineItemLockDetails]): DocumentDetails =
+      emptyDocumentDetails.copy(
+        lineItemDetails = Seq(emptyLineItem.copy(
+          netDueDate = Some(LocalDate.parse(dueDate)),
+          lineItemLockDetails = lockDetails
+        ))
+      )
+
+    "return true" when {
+
+      "there is an overdue charge and no payment locks" in {
+        val docDetails = generateDocDetails("2018-01-01", Seq())
+        FinancialTransactions.hasOverdueChargeAndNoTTP(Seq(docDetails)) shouldBe true
+      }
+
+      "there is an overdue charge and irrelevant payment lock values" in {
+        val docDetails = generateDocDetails("2018-01-01", Seq(LineItemLockDetails("Some lock reason")))
+        FinancialTransactions.hasOverdueChargeAndNoTTP(Seq(docDetails)) shouldBe true
+      }
+    }
+
+    "return false" when {
+
+      "there is an overdue charge and a TTP payment lock value" in {
+        val docDetails = generateDocDetails("2018-01-01", Seq(LineItemLockDetails("Collected via TTP")))
+        FinancialTransactions.hasOverdueChargeAndNoTTP(Seq(docDetails)) shouldBe false
+      }
+
+      "there is an overdue charge and there are multiple TTP payment lock values" in {
+        val docDetails = generateDocDetails(
+          "2018-01-01", Seq(LineItemLockDetails("Collected via TTP"), LineItemLockDetails("Collected via TTP"))
+        )
+        FinancialTransactions.hasOverdueChargeAndNoTTP(Seq(docDetails)) shouldBe false
+      }
+
+      "there is an overdue charge without a TTP lock and a due charge with a TTP lock" in {
+        val docDetails1 = generateDocDetails("2018-01-01", Seq())
+        val docDetails2 = generateDocDetails("2019-01-01", Seq(LineItemLockDetails("Collected via TTP")))
+        FinancialTransactions.hasOverdueChargeAndNoTTP(Seq(docDetails1, docDetails2)) shouldBe false
+      }
+
+      "there are no overdue charges and a TTP payment lock value" in {
+        val docDetails = generateDocDetails("2019-01-01", Seq(LineItemLockDetails("Collected via TTP")))
+        FinancialTransactions.hasOverdueChargeAndNoTTP(Seq(docDetails)) shouldBe false
+      }
+
+      "there are no overdue charges and irrelevant payment lock values" in {
+        val docDetails = generateDocDetails("2019-01-01", Seq(LineItemLockDetails("Some lock reason")))
+        FinancialTransactions.hasOverdueChargeAndNoTTP(Seq(docDetails)) shouldBe false
+      }
+
+      "there are no overdue charges and no payment locks" in {
+        val docDetails = generateDocDetails("2019-01-01", Seq())
+        FinancialTransactions.hasOverdueChargeAndNoTTP(Seq(docDetails)) shouldBe false
+      }
+
+      "the charges have no due dates" in {
+        FinancialTransactions.hasOverdueChargeAndNoTTP(Seq(emptyDocumentDetails)) shouldBe false
       }
     }
   }

--- a/test/models/API1811/LineItemLockDetailsSpec.scala
+++ b/test/models/API1811/LineItemLockDetailsSpec.scala
@@ -14,18 +14,17 @@
  * limitations under the License.
  */
 
-package services
+package models.API1811
 
-import java.time.LocalDate
+import base.SpecBase
+import play.api.libs.json.Json
 
-object DateService {
+class LineItemLockDetailsSpec extends SpecBase {
 
-  def now(implicit appConfig: config.AppConfig): LocalDate = {
-    if (appConfig.features.staticDate()) {
-      LocalDate.parse(appConfig.staticDateValue)
-    } else {
-      LocalDate.now()
+  "LineItemLockDetails" should {
+
+    "read from JSON" in {
+      Json.obj("lockType" -> "Some lock reason").as[LineItemLockDetails] shouldBe LineItemLockDetails("Some lock reason")
     }
   }
-
 }

--- a/test/utils/API1811/TestConstants.scala
+++ b/test/utils/API1811/TestConstants.scala
@@ -16,7 +16,7 @@
 
 package utils.API1811
 
-import models.API1811.{DocumentDetails, FinancialTransactions, LineItemDetails}
+import models.API1811.{DocumentDetails, FinancialTransactions, LineItemDetails, LineItemLockDetails}
 import play.api.libs.json.{JsObject, Json}
 
 import java.time.LocalDate
@@ -35,7 +35,8 @@ object TestConstants {
     clearingDate = Some(LocalDate.parse("2017-08-06")),
     clearingReason = Some("Payment at External Payment Collector Reported"),
     clearingDocument = Some("719283701921"),
-    interestRate = Some(3.00)
+    interestRate = Some(3.00),
+    lineItemLockDetails = Seq(LineItemLockDetails("Some lock reason"))
   )
 
   val lineItemDetailsFullJson: JsObject = Json.obj(
@@ -52,7 +53,10 @@ object TestConstants {
     ),
     "clearingDate" -> "2017-08-06",
     "clearingReason" -> "Payment at External Payment Collector Reported",
-    "clearingDocument" -> "719283701921"
+    "clearingDocument" -> "719283701921",
+    "lineItemLockDetails" -> Json.arr(Json.obj(
+      "lockType" -> "Some lock reason"
+    ))
   )
 
   val lineItemDetailsJsonBadCharge: JsObject = Json.obj(
@@ -88,7 +92,10 @@ object TestConstants {
     ),
     "clearingDate" -> "2017-08-06",
     "clearingReason" -> "Payment at External Payment Collector Reported",
-    "clearingDocument" -> "719283701921"
+    "clearingDocument" -> "719283701921",
+    "lineItemLockDetails" -> Json.arr(Json.obj(
+      "lockType" -> "Some lock reason"
+    ))
   )
 
   val fullDocumentDetails: DocumentDetails = DocumentDetails(
@@ -156,8 +163,10 @@ object TestConstants {
     documentTotalAmount = None
   )
 
-  val emptyLineItem: LineItemDetails = LineItemDetails(None, None, None, None, None, None, None, None, None, None, None, None)
-  val emptyDocumentDetails: DocumentDetails = DocumentDetails(None, None, None, None, Seq(emptyLineItem), None, None, None, None)
+  val emptyLineItem: LineItemDetails =
+    LineItemDetails(None, None, None, None, None, None, None, None, None, None, None, None, Seq())
+  val emptyDocumentDetails: DocumentDetails =
+    DocumentDetails(None, None, None, None, Seq(emptyLineItem), None, None, None, None)
 
   def fullFTJson(documentDetails: JsObject): JsObject = Json.obj(
     "getFinancialData" -> Json.obj(
@@ -201,6 +210,7 @@ object TestConstants {
   )
 
   val fullFinancialTransactionsOutputJson: JsObject = Json.obj(
-    "financialTransactions" -> Json.arr(fullDocumentDetailsOutputJson)
+    "financialTransactions" -> Json.arr(fullDocumentDetailsOutputJson),
+    "hasOverdueChargeAndNoTTP" -> true
   )
 }


### PR DESCRIPTION
The following test case:

"there is an overdue charge without a TTP lock and a due charge with a TTP lock"

this logic was confirmed with Martin - "If there is any TTP place the user cannot set up another one" ... "the TTP can only be put in place IF the charge is overdue" - so the scenario is not believed to be possible in reality, but still worth testing our logic.