### PR TITLE
Improved connector logging for EIS calls

### DIFF
--- a/app/connectors/API1811/httpParsers/FinancialTransactionsHttpParser.scala
+++ b/app/connectors/API1811/httpParsers/FinancialTransactionsHttpParser.scala
@@ -50,8 +50,6 @@ class FinancialTransactionsHttpParser @Inject()(implicit appConfig: Microservice
           logger.debug("[FinancialTransactionsReads][read] Error received: " + response)
           Left(Error(response.status,response.body))
         case _ =>
-          logger.warn(s"[FinancialTransactionsReads][read] unexpected ${response.status} returned from EIS " +
-          s"Status code:'${response.status}', Body: '${response.body}")
           Left(Error(response.status, response.body))
       }
   }

--- a/app/connectors/API1812/httpParsers/PenaltyDetailsHttpParser.scala
+++ b/app/connectors/API1812/httpParsers/PenaltyDetailsHttpParser.scala
@@ -45,11 +45,8 @@ object PenaltyDetailsHttpParser extends LoggerUtil {
           logger.debug("[PenaltyDetailsReads][read] Error received: " + response)
           Left(Error(response.status,response.body))
         case _ =>
-          logger.warn(s"[PenaltyDetailsReads][read] unexpected ${response.status} returned from EIS " +
-            s"Status code:'${response.status}', Body: '${response.body}")
           Left(Error(response.status, response.body))
       }
     }
   }
-
 }


### PR DESCRIPTION
Connectors are now logging correlation IDs for easier live service issue investigation. I've removed some logs from the HTTP parsers and moved the information into the connectors to avoid unnecessary noise.