### PR TITLE
BTAT-11511 Added HttpException recovery to connectors

### DIFF
--- a/app/connectors/API1811/FinancialDataConnector.scala
+++ b/app/connectors/API1811/FinancialDataConnector.scala
@@ -17,11 +17,11 @@
 package connectors.API1811
 
 import config.MicroserviceAppConfig
-import connectors.API1811.httpParsers.FinancialTransactionsHttpParser
-import connectors.API1811.httpParsers.FinancialTransactionsHttpParser.FinancialTransactionsResponse
+import connectors.API1811.httpParsers.FinancialTransactionsHttpParser.{FinancialTransactionsReads, FinancialTransactionsResponse}
+import models.API1811.Error
 import models.{FinancialRequestQueryParameters, TaxRegime}
-import play.api.http.Status.NOT_FOUND
-import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
+import play.api.http.Status.{BAD_GATEWAY, NOT_FOUND}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpException}
 import utils.LoggerUtil
 
 import java.util.UUID.randomUUID
@@ -29,7 +29,7 @@ import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class FinancialDataConnector @Inject()(http: HttpClient, httpParser: FinancialTransactionsHttpParser)
+class FinancialDataConnector @Inject()(http: HttpClient)
                                       (implicit appConfig: MicroserviceAppConfig) extends LoggerUtil {
 
   private[connectors] def financialDataUrl(regime: TaxRegime) =
@@ -52,12 +52,16 @@ class FinancialDataConnector @Inject()(http: HttpClient, httpParser: FinancialTr
     logger.debug("[FinancialDataConnector][getFinancialData] - " +
       s"Calling GET $url \nHeaders: $eisHeaders\n QueryParams: ${queryParameters.queryParams1811}")
 
-    http.GET(url, queryParameters.queryParams1811, eisHeaders)(httpParser.FinancialTransactionsReads, hc, ec).map {
+    http.GET(url, queryParameters.queryParams1811, eisHeaders)(FinancialTransactionsReads, hc, ec).map {
       case Left(error) if error.code != NOT_FOUND =>
         logger.warn(s"[FinancialDataConnector][getFinancialData] Unexpected error returned by EIS. " +
           s"Status code: ${error.code}, Body: ${error.reason.trim}, Correlation ID: $correlationID")
         Left(error)
       case expectedResponse => expectedResponse
+    }.recover {
+      case ex: HttpException =>
+        logger.warn(s"[FinancialDataConnector][getFinancialData] - HTTP exception received: ${ex.message}")
+        Left(Error(BAD_GATEWAY, ex.message))
     }
   }
 }

--- a/app/connectors/API1811/httpParsers/FinancialTransactionsHttpParser.scala
+++ b/app/connectors/API1811/httpParsers/FinancialTransactionsHttpParser.scala
@@ -16,17 +16,15 @@
 
 package connectors.API1811.httpParsers
 
-import connectors.API1811.httpParsers.FinancialTransactionsHttpParser.FinancialTransactionsResponse
 import models.API1811.{Error, FinancialTransactions}
 import play.api.http.Status.{BAD_REQUEST, NOT_FOUND, OK}
 import uk.gov.hmrc.http.{HttpReads, HttpResponse}
 import utils.API1811.ChargeTypes
 import utils.LoggerUtil
 
-import javax.inject.{Inject, Singleton}
+object FinancialTransactionsHttpParser extends LoggerUtil {
 
-@Singleton
-class FinancialTransactionsHttpParser @Inject() extends LoggerUtil {
+  type FinancialTransactionsResponse = Either[Error, FinancialTransactions]
 
   implicit object FinancialTransactionsReads extends HttpReads[FinancialTransactionsResponse] {
     override def read(method: String, url: String, response: HttpResponse): FinancialTransactionsResponse =
@@ -52,8 +50,4 @@ class FinancialTransactionsHttpParser @Inject() extends LoggerUtil {
           Left(Error(response.status, response.body))
       }
   }
-}
-
-object FinancialTransactionsHttpParser {
-  type FinancialTransactionsResponse = Either[Error, FinancialTransactions]
 }

--- a/app/connectors/API1812/PenaltyDetailsConnector.scala
+++ b/app/connectors/API1812/PenaltyDetailsConnector.scala
@@ -19,8 +19,9 @@ package connectors.API1812
 import config.MicroserviceAppConfig
 import connectors.API1812.httpParsers.PenaltyDetailsHttpParser.{PenaltyDetailsReads, PenaltyDetailsResponse}
 import models.{PenaltyDetailsQueryParameters, TaxRegime}
-import play.api.http.Status.NOT_FOUND
-import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
+import models.API1812.Error
+import play.api.http.Status.{BAD_GATEWAY, NOT_FOUND}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpException}
 import utils.LoggerUtil
 
 import java.util.UUID.randomUUID
@@ -56,6 +57,10 @@ class PenaltyDetailsConnector @Inject()(val http: HttpClient, val appConfig: Mic
           s"Status code: ${error.code}, Body: ${error.reason.trim}, Correlation ID: $correlationID")
         Left(error)
       case expectedResponse => expectedResponse
+    }.recover {
+      case ex: HttpException =>
+        logger.warn(s"[PenaltyDetailsConnector][getPenaltyDetails] - HTTP exception received: ${ex.message}")
+        Left(Error(BAD_GATEWAY, ex.message))
     }
   }
 }

--- a/app/controllers/FinancialTransactionsController.scala
+++ b/app/controllers/FinancialTransactionsController.scala
@@ -59,11 +59,6 @@ class FinancialTransactionsController @Inject()(authenticate: AuthAction,
     api1811Service.getFinancialTransactions(regime, queryParams).map {
       case Right(financialTransactions) => Ok(Json.toJson(financialTransactions))
       case Left(error) => Status(error.code)(Json.toJson(error))
-    }.recover {
-      case ex =>
-        logger.warn("[FinancialTransactionsController][retrieveFinancialTransactionsAPI1811] - " +
-          s"Exception received when retrieving data: ${ex.getMessage}, returning status code 500")
-        InternalServerError(Json.toJson(API1811.Error(INTERNAL_SERVER_ERROR, ex.getMessage)))
     }
   }
 

--- a/it/connectors/API1811/FinancialDataConnectorISpec.scala
+++ b/it/connectors/API1811/FinancialDataConnectorISpec.scala
@@ -16,7 +16,6 @@
 
 package connectors.API1811
 
-import connectors.API1811.httpParsers.FinancialTransactionsHttpParser
 import connectors.API1811.httpParsers.FinancialTransactionsHttpParser.FinancialTransactionsResponse
 import helpers.ComponentSpecBase
 import models.API1811.Error
@@ -28,8 +27,7 @@ import testData.FinancialData1811.{fullFinancialTransactions, fullFinancialTrans
 
 class FinancialDataConnectorISpec extends ComponentSpecBase {
 
-  val httpParser = new FinancialTransactionsHttpParser()
-  val connector: FinancialDataConnector = new FinancialDataConnector(httpClient, httpParser)
+  val connector: FinancialDataConnector = new FinancialDataConnector(httpClient)
 
   val regimeType = "VATC"
   val invalidRegimeType = "9"

--- a/test/connectors/API1811/FinancialDataConnectorSpec.scala
+++ b/test/connectors/API1811/FinancialDataConnectorSpec.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors.API1811
+
+import base.SpecBase
+import mocks.MockHttp
+import models.{FinancialRequestQueryParameters, VatRegime}
+import models.API1811.Error
+import play.api.http.Status.BAD_GATEWAY
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
+import uk.gov.hmrc.http.RequestTimeoutException
+
+import scala.concurrent.Future
+
+class FinancialDataConnectorSpec extends SpecBase with MockHttp {
+
+  val connector = new FinancialDataConnector(mockHttpGet)
+  val vatRegime: VatRegime = VatRegime("555555555")
+  val queryParams: FinancialRequestQueryParameters = FinancialRequestQueryParameters()
+
+  "The FinancialDataConnector" should {
+
+    "return a 502 error when there is a HTTP exception" in {
+      val exception = new RequestTimeoutException("Request timed out!!!")
+      setupMockHttpGet(connector.financialDataUrl(vatRegime), queryParams.queryParams1811)(Future.failed(exception))
+      val result = connector.getFinancialData(vatRegime, queryParams)
+      await(result) shouldBe Left(Error(BAD_GATEWAY, exception.message))
+    }
+  }
+}

--- a/test/connectors/API1811/httpParsers/FinancialTransactionsHttpParserSpec.scala
+++ b/test/connectors/API1811/httpParsers/FinancialTransactionsHttpParserSpec.scala
@@ -26,8 +26,6 @@ import utils.API1811.TestConstants._
 
 class FinancialTransactionsHttpParserSpec extends SpecBase {
 
-  val httpParser = new FinancialTransactionsHttpParser()
-
   "The FinancialTransactionsHttpParser" when {
 
     "the http response status is 200 OK and matches expected Schema" when {
@@ -38,7 +36,7 @@ class FinancialTransactionsHttpParserSpec extends SpecBase {
 
         val expected = Right(fullFinancialTransactions)
 
-        val result = httpParser.FinancialTransactionsReads.read("", "", httpResponse)
+        val result = FinancialTransactionsHttpParser.FinancialTransactionsReads.read("", "", httpResponse)
 
         "return a FinancialTransactions instance containing financialDetails items with valid charge types" in {
           result shouldEqual expected
@@ -51,7 +49,7 @@ class FinancialTransactionsHttpParserSpec extends SpecBase {
 
         val expected = Right(fullFinancialTransactions.copy(documentDetails = Seq()))
 
-        val result = httpParser.FinancialTransactionsReads.read("", "", httpResponse)
+        val result = FinancialTransactionsHttpParser.FinancialTransactionsReads.read("", "", httpResponse)
 
         "return a FinancialTransactions instance that has had the invalid financialDetails items filtered out" in {
           result shouldEqual expected
@@ -66,7 +64,7 @@ class FinancialTransactionsHttpParserSpec extends SpecBase {
       val expected = Left(Error(BAD_REQUEST,
         "UNEXPECTED_JSON_FORMAT - The downstream service responded with json which did not match the expected format."))
 
-      val result = httpParser.FinancialTransactionsReads.read("", "", httpResponse)
+      val result = FinancialTransactionsHttpParser.FinancialTransactionsReads.read("", "", httpResponse)
 
       "return an Error model with an UNEXPECTED_JSON_FORMAT error message" in {
         result shouldEqual expected
@@ -79,7 +77,7 @@ class FinancialTransactionsHttpParserSpec extends SpecBase {
 
       val expected = Left(Error(Status.NOT_FOUND,""))
 
-      val result = httpParser.FinancialTransactionsReads.read("", "", httpResponse)
+      val result = FinancialTransactionsHttpParser.FinancialTransactionsReads.read("", "", httpResponse)
 
       "return a NOT_FOUND status in an Error model" in {
         result shouldEqual expected
@@ -92,7 +90,7 @@ class FinancialTransactionsHttpParserSpec extends SpecBase {
 
       val expected = Left(Error( code = INTERNAL_SERVER_ERROR, reason = "message"))
 
-      val result = httpParser.FinancialTransactionsReads.read("", "", httpResponse)
+      val result = FinancialTransactionsHttpParser.FinancialTransactionsReads.read("", "", httpResponse)
 
       "return the status in an Error model" in {
         result shouldEqual expected

--- a/test/connectors/API1812/PenaltyDetailsConnectorSpec.scala
+++ b/test/connectors/API1812/PenaltyDetailsConnectorSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors.API1812
+
+import base.SpecBase
+import mocks.MockHttp
+import models.{PenaltyDetailsQueryParameters, VatRegime}
+import models.API1812.Error
+import play.api.http.Status.BAD_GATEWAY
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
+import uk.gov.hmrc.http.RequestTimeoutException
+
+import scala.concurrent.Future
+
+class PenaltyDetailsConnectorSpec extends SpecBase with MockHttp {
+
+  val connector = new PenaltyDetailsConnector(mockHttpGet, mockAppConfig)
+  val vatRegime: VatRegime = VatRegime("555555555")
+  val queryParams: PenaltyDetailsQueryParameters = PenaltyDetailsQueryParameters()
+
+  "The PenaltyDetailsConnector" should {
+
+    "return a 502 error when there is a HTTP exception" in {
+      val exception = new RequestTimeoutException("Request timed out!!!")
+      setupMockHttpGet(connector.penaltyDetailsUrl(vatRegime))(Future.failed(exception))
+      val result = connector.getPenaltyDetails(vatRegime, queryParams)
+      await(result) shouldBe Left(Error(BAD_GATEWAY, exception.message))
+    }
+  }
+}
+

--- a/test/controllers/FinancialTransactionsControllerSpec.scala
+++ b/test/controllers/FinancialTransactionsControllerSpec.scala
@@ -55,93 +55,74 @@ class FinancialTransactionsControllerSpec extends SpecBase
 
   "The GET FinancialTransactionsController.getFinancialTransactions method" when {
 
-        val badRequestError = Error1811(Status.BAD_REQUEST, "error")
-        val successResponse = Future.successful(Right(fullFinancialTransactions1811))
-        val errorResponse = Future.successful(Left(badRequestError))
-        val exceptionResponse = Future.failed(new Exception("oops"))
+    val badRequestError = Error1811(Status.BAD_REQUEST, "error")
+    val successResponse = Future.successful(Right(fullFinancialTransactions1811))
+    val errorResponse = Future.successful(Left(badRequestError))
 
-        "an authenticated user requests VAT details" when {
+    "an authenticated user requests VAT details" when {
 
-          val id = "123456"
-          val regimeType = "VAT"
-          val vatRegime = VatRegime(id)
+      val id = "123456"
+      val regimeType = "VAT"
+      val vatRegime = VatRegime(id)
 
-          "the service returns a success response" should {
+      "the service returns a success response" should {
 
-            lazy val result = {
-              setupMock1811GetFinancialTransactions(vatRegime, FinancialRequestQueryParameters())(successResponse)
-              TestFinancialTransactionController.getFinancialTransactions(
-                regimeType, id, FinancialRequestQueryParameters()
-              )(fakeRequest)
-            }
-
-            "return a status of 200 (OK)" in {
-              status(result) shouldBe Status.OK
-            }
-
-            "return a json body with the financial transaction information" in {
-              contentAsJson(result) shouldBe fullFinancialTransactionsOutputJson
-            }
-          }
-
-          "the service returns a failure response" should {
-
-            lazy val result = {
-              setupMock1811GetFinancialTransactions(vatRegime, FinancialRequestQueryParameters())(errorResponse)
-              TestFinancialTransactionController.getFinancialTransactions(
-                regimeType, id, FinancialRequestQueryParameters()
-              )(fakeRequest)
-            }
-
-            "return the same status as the response" in {
-              status(result) shouldBe Status.BAD_REQUEST
-            }
-
-            "return the correct error JSON" in {
-              contentAsJson(result) shouldBe Json.toJson(badRequestError)
-            }
-          }
-
-          "an exception has been thrown at an earlier stage" should {
-
-            lazy val result = {
-              setupMock1811GetFinancialTransactions(vatRegime, FinancialRequestQueryParameters())(exceptionResponse)
-              TestFinancialTransactionController.getFinancialTransactions(
-                regimeType, id, FinancialRequestQueryParameters()
-              )(fakeRequest)
-            }
-
-            "return a status of 500 (INTERNAL_SERVER_ERROR)" in {
-              status(result) shouldBe Status.INTERNAL_SERVER_ERROR
-            }
-
-            "return an error json body" in {
-              contentAsJson(result) shouldBe Json.obj("code" -> 500, "reason" -> "oops")
-            }
-          }
+        lazy val result = {
+          setupMock1811GetFinancialTransactions(vatRegime, FinancialRequestQueryParameters())(successResponse)
+          TestFinancialTransactionController.getFinancialTransactions(
+            regimeType, id, FinancialRequestQueryParameters()
+          )(fakeRequest)
         }
 
-        "an authenticated user requests details for an invalid tax regime" should {
-
-          val regimeType = "BANANA"
-          val id = "123456"
-          val vatRegime = VatRegime(id)
-
-          lazy val result = {
-            setupMock1811GetFinancialTransactions(vatRegime, FinancialRequestQueryParameters())(errorResponse)
-            TestFinancialTransactionController.getFinancialTransactions(
-              regimeType, id, FinancialRequestQueryParameters()
-            )(fakeRequest)
-          }
-
-          "return a status of 400 (BAD_REQUEST)" in {
-            status(result) shouldBe Status.BAD_REQUEST
-          }
-
-          "return a json body with an Invalid Tax Regime message" in {
-            contentAsJson(result) shouldBe Json.toJson(InvalidTaxRegime)
-          }
+        "return a status of 200 (OK)" in {
+          status(result) shouldBe Status.OK
         }
+
+        "return a json body with the financial transaction information" in {
+          contentAsJson(result) shouldBe fullFinancialTransactionsOutputJson
+        }
+      }
+
+      "the service returns a failure response" should {
+
+        lazy val result = {
+          setupMock1811GetFinancialTransactions(vatRegime, FinancialRequestQueryParameters())(errorResponse)
+          TestFinancialTransactionController.getFinancialTransactions(
+            regimeType, id, FinancialRequestQueryParameters()
+          )(fakeRequest)
+        }
+
+        "return the same status as the response" in {
+          status(result) shouldBe Status.BAD_REQUEST
+        }
+
+        "return the correct error JSON" in {
+          contentAsJson(result) shouldBe Json.toJson(badRequestError)
+        }
+      }
+    }
+
+    "an authenticated user requests details for an invalid tax regime" should {
+
+      val regimeType = "BANANA"
+      val id = "123456"
+      val vatRegime = VatRegime(id)
+
+      lazy val result = {
+        setupMock1811GetFinancialTransactions(vatRegime, FinancialRequestQueryParameters())(errorResponse)
+        TestFinancialTransactionController.getFinancialTransactions(
+          regimeType, id, FinancialRequestQueryParameters()
+        )(fakeRequest)
+      }
+
+      "return a status of 400 (BAD_REQUEST)" in {
+        status(result) shouldBe Status.BAD_REQUEST
+      }
+
+      "return a json body with an Invalid Tax Regime message" in {
+        contentAsJson(result) shouldBe Json.toJson(InvalidTaxRegime)
+      }
+    }
   }
 
   "The GET FinancialTransactionsController.checkDirectDebitExists method" when {

--- a/test/mocks/MockHttp.scala
+++ b/test/mocks/MockHttp.scala
@@ -24,7 +24,6 @@ import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatest.{BeforeAndAfterEach, OptionValues}
-import uk.gov.hmrc.http.HttpResponse
 import uk.gov.hmrc.http.HttpClient
 
 import scala.concurrent.Future
@@ -38,15 +37,11 @@ trait MockHttp extends AnyWordSpecLike with Matchers with OptionValues with Befo
     reset(mockHttpGet)
   }
 
-  def setupMockHttpGet[A](url: String)(response: A): OngoingStubbing[Future[A]] =
+  def setupMockHttpGet[A](url: String)(response: Future[A]): OngoingStubbing[Future[A]] =
     when(mockHttpGet.GET[A](ArgumentMatchers.eq(url), any(), any())(any(), any(), any()))
-      .thenReturn(Future.successful(response))
+      .thenReturn(response)
 
-  def setupMockHttpGet[A](url: String, queryParams: Seq[(String, String)])(response: A): OngoingStubbing[Future[A]] =
+  def setupMockHttpGet[A](url: String, queryParams: Seq[(String, String)])(response: Future[A]): OngoingStubbing[Future[A]] =
     when(mockHttpGet.GET[A](ArgumentMatchers.eq(url), ArgumentMatchers.eq(queryParams), any())(any(),
-      any(), any())).thenReturn(Future.successful(response))
-
-  def setupMockFailedHttpGet[A](url: String)(response: HttpResponse): OngoingStubbing[Future[A]] =
-    when(mockHttpGet.GET[A](ArgumentMatchers.eq(url))(any(), any(), any())).thenReturn(Future.failed(new Exception))
-
+      any(), any())).thenReturn(response)
 }


### PR DESCRIPTION
Please also merge: https://github.com/hmrc/app-config-production/pull/17937

I had to write unit tests for the exception cases as I'm not aware of a way with Wiremock to stub an exception.
I also changed one HTTP parser to be an object to match the pattern of other parsers