### PR TITLE
[DL-17179] Replace API#1812 auth token from 'Bearer*' to 'Basic*'

### DIFF
--- a/app/connectors/API1812/HIPPenaltyDetailsConnector.scala
+++ b/app/connectors/API1812/HIPPenaltyDetailsConnector.scala
@@ -42,7 +42,7 @@ class HIPPenaltyDetailsConnector @Inject()(val http: HttpClient, val appConfig: 
     val receiptDate = LocalDateTime.now(ZoneOffset.UTC).format(java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'"))
 
     val hipHeaders = Seq(
-      "Authorization" -> s"Bearer ${appConfig.hipToken}",
+      "Authorization" -> s"Basic ${appConfig.hipToken}",
       "correlationid" -> correlationID,
       "X-Originating-System" -> "MDTP",
       "X-Receipt-Date" -> receiptDate,

--- a/it/helpers/servicemocks/HIPPenaltyDetailsStub.scala
+++ b/it/helpers/servicemocks/HIPPenaltyDetailsStub.scala
@@ -44,7 +44,7 @@ object HIPPenaltyDetailsStub {
   def stubGetPenaltyDetailsWithHeaderValidation(regime: TaxRegime, queryParams: PenaltyDetailsQueryParameters)
                                               (status: Int, response: JsValue): StubMapping = {
     stubFor(get(urlEqualTo(penaltyDetailsUrl(regime, queryParams)))
-      .withHeader("Authorization", matching("Bearer .*"))
+      .withHeader("Authorization", matching("Basic .*"))
       .withHeader("correlationid", matching("^[0-9a-fA-F]{8}[-][0-9a-fA-F]{4}[-][0-9a-fA-F]{4}[-][0-9a-fA-F]{4}[-][0-9a-fA-F]{12}$"))
       .withHeader("X-Originating-System", matching(".*"))
       .withHeader("X-Receipt-Date", matching("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"))

--- a/test/connectors/API1812/HIPPenaltyDetailsConnectorSpec.scala
+++ b/test/connectors/API1812/HIPPenaltyDetailsConnectorSpec.scala
@@ -66,7 +66,7 @@ class HIPPenaltyDetailsConnectorSpec extends SpecBase with MockHttp {
       val capturedHeaders = headerCaptor.getValue
       val capturedQueryParams = queryParamCaptor.getValue
 
-      capturedHeaders should contain("Authorization" -> s"Bearer ${mockAppConfig.hipToken}")
+      capturedHeaders should contain("Authorization" -> s"Basic ${mockAppConfig.hipToken}")
       capturedHeaders.exists(_._1 == "correlationid") shouldBe true
       capturedHeaders should contain("X-Originating-System" -> "MDTP")
       capturedHeaders should contain("X-Transmitting-System" -> "HIP")


### PR DESCRIPTION
Can't find information on it in the spec: https://admin.tax.service.gov.uk/integration-hub/apis/view-specification/79209ad9-54ea-4044-9115-b1b077bc223c/test

But it works with 'Basic *' in...
- FT 1811
    - https://build.tax.service.gov.uk/job/PlatformTools/job/curl-microservice/13179/console
    - https://github.com/hmrc/financial-transactions/blob/main/app/connectors/API1811/FinancialDataHIPConnector.scala#L62
- penalties 1811
    - https://github.com/hmrc/penalties/blob/main/app/connectors/getFinancialDetails/FinancialDetailsHipConnector.scala#L41
- penalties 1812
    -  https://github.com/hmrc/penalties/blob/main/app/connectors/getPenaltyDetails/HIPPenaltyDetailsConnector.scala#L106

It is only FT 1812 where is it 'Bearer *' instead