### PR TITLE
[DL-17214] Fix error handling, add tests, ensure tests handle HIP config on/off

### DIFF
--- a/app/connectors/API1811/FinancialDataHIPConnector.scala
+++ b/app/connectors/API1811/FinancialDataHIPConnector.scala
@@ -17,12 +17,12 @@
 package connectors.API1811
 
 import config.MicroserviceAppConfig
-import connectors.API1811.httpParsers.FinancialTransactionsHttpHIPParser.{FinancialTransactionsFailureResponse, FinancialTransactionsHIPReads, FinancialTransactionsHIPResponse}
-import models.API1811.{FinancialRequestHIP, FinancialRequestHIPHelper}
+import connectors.API1811.httpParsers.FinancialTransactionsHttpHIPParser.{FinancialTransactionsHIPReads, FinancialTransactionsHIPResponse}
+import models.API1811.{Error, FinancialRequestHIP, FinancialRequestHIPHelper}
 import models.{FinancialRequestQueryParameters, TaxRegime}
-import play.api.http.Status.INTERNAL_SERVER_ERROR
+import play.api.http.Status.BAD_GATEWAY
 import play.api.libs.json.{JsValue, Json}
-import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpException}
 import utils.LoggerUtil
 
 import java.time.Instant
@@ -53,9 +53,9 @@ class FinancialDataHIPConnector @Inject()(http: HttpClient)
       headerCarrier,
       ec
     ).recover {
-      case ex: Exception =>
-        logger.warn(s"[FinancialDataHIPConnector][getFinancialDataHIP] HIP HTTP exception received: ${ex.getMessage}")
-        Left(FinancialTransactionsFailureResponse(INTERNAL_SERVER_ERROR))
+      case ex: HttpException =>
+        logger.warn(s"[FinancialDataHIPConnector][getFinancialDataHIP] - HTTP exception received: ${ex.message}")
+        Left(Error(BAD_GATEWAY, ex.message))
     }
   }
   private def buildHIPHeaders(correlationId: String): Seq[(String, String)] = Seq(

--- a/app/connectors/API1812/httpParsers/HIPPenaltyDetailsHttpParser.scala
+++ b/app/connectors/API1812/httpParsers/HIPPenaltyDetailsHttpParser.scala
@@ -80,7 +80,7 @@ object HIPPenaltyDetailsHttpParser extends LoggerUtil {
     val json = Try(response.json).getOrElse(Json.obj())
 
     val technicalError = json.validate[HIPTechnicalErrorResponse].asOpt
-    val businessError = json.validate[HIPErrorResponse].asOpt  
+    val businessError = json.validate[HIPErrorResponse].asOpt
     val failureResponse = json.validate[HIPFailureResponse].asOpt
     val originResponse = json.validate[HIPOriginResponse].asOpt
 

--- a/app/models/API1811/BusinessError.scala
+++ b/app/models/API1811/BusinessError.scala
@@ -16,13 +16,9 @@
 
 package models.API1811
 
-import connectors.API1811.httpParsers.FinancialTransactionsHttpHIPParser.FinancialTransactionsFailure
 import play.api.libs.json.{Format, Json}
 
-case class BusinessError(
-                          processingDate: String,
-                          code: String,
-                          text: String) extends FinancialTransactionsFailure
+case class BusinessError(processingDate: String, code: String, text: String)
 
 object BusinessError {
   implicit val format: Format[BusinessError] = Json.format[BusinessError]

--- a/app/models/API1811/TechnicalError.scala
+++ b/app/models/API1811/TechnicalError.scala
@@ -16,13 +16,9 @@
 
 package models.API1811
 
-import connectors.API1811.httpParsers.FinancialTransactionsHttpHIPParser.FinancialTransactionsFailure
 import play.api.libs.json.{Format, Json}
 
-case class TechnicalError(
-                           code: String,
-                           message: String,
-                           logId: String) extends FinancialTransactionsFailure
+case class TechnicalError(code: String, message: String, logId: String)
 
 object TechnicalError {
   implicit val format: Format[TechnicalError] = Json.format[TechnicalError]

--- a/app/services/API1811/FinancialTransactionsService.scala
+++ b/app/services/API1811/FinancialTransactionsService.scala
@@ -18,12 +18,10 @@ package services.API1811
 
 import com.google.inject.Inject
 import config.MicroserviceAppConfig
-import connectors.API1811.httpParsers.FinancialTransactionsHttpHIPParser.FinancialTransactionsNoContent
 import connectors.API1811.httpParsers.FinancialTransactionsHttpParser.FinancialTransactionsResponse
 import connectors.API1811.{FinancialDataConnector, FinancialDataHIPConnector}
-import models.API1811.{BusinessError, Error, FinancialTransactions, TechnicalError}
+import models.API1811.{Error, FinancialTransactions}
 import models.{FinancialRequestQueryParameters, TaxRegime}
-import play.api.http.Status
 import play.api.mvc.Request
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.API1811.ChargeTypes
@@ -31,11 +29,14 @@ import utils.LoggerUtil
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class FinancialTransactionsService @Inject()(val connector: FinancialDataConnector,
-                                             val hipConnector: FinancialDataHIPConnector,
-                                             implicit val ec: ExecutionContext) extends LoggerUtil {
-  def getFinancialTransactions(regime: TaxRegime, queryParameters: FinancialRequestQueryParameters
-                              )(implicit headerCarrier: HeaderCarrier, appConfig: MicroserviceAppConfig, request: Request[_]): Future[FinancialTransactionsResponse] = {
+class FinancialTransactionsService @Inject() (val connector: FinancialDataConnector,
+                                              val hipConnector: FinancialDataHIPConnector,
+                                              implicit val ec: ExecutionContext)
+    extends LoggerUtil {
+  def getFinancialTransactions(regime: TaxRegime, queryParameters: FinancialRequestQueryParameters)(implicit
+      headerCarrier: HeaderCarrier,
+      appConfig: MicroserviceAppConfig,
+      request: Request[_]): Future[FinancialTransactionsResponse] = {
 
     if (appConfig.features.enable1811HIPCall()) {
       logger.info("[FinancialTransactionsService][getFinancialTransactions] - HIP Call enabled, calling FinancialDataHIPConnector")
@@ -43,31 +44,17 @@ class FinancialTransactionsService @Inject()(val connector: FinancialDataConnect
         case Right(financialTransactionsHIP) =>
           logger.info("[FinancialTransactionsService][getFinancialTransactions] - Successfully retrieved HIP financial transactions.")
           val filteredDocumentDetails = ChargeTypes.removeInvalidCharges(financialTransactionsHIP.financialData.documentDetails)
-          val mappedToIf = FinancialTransactions(documentDetails = filteredDocumentDetails)
-          Right(mappedToIf)
+          Right(FinancialTransactions(documentDetails = filteredDocumentDetails))
 
-        case Left(FinancialTransactionsNoContent) =>
-          logger.warn(s"[FinancialTransactionsService] 404 - Financial data not found for ${regime.idType} ${regime.id}")
-          Left(Error(Status.NOT_FOUND, s"${Status.NOT_FOUND}: Financial data not found for ${regime.idType} ${regime.id}"))
-
-        case Left(businessError: BusinessError) =>
-          logger.warn(s"[FinancialTransactionsService] HIP returned BusinessError: ${businessError.code} - ${businessError.text}")
-          Left(Error(Status.BAD_REQUEST, s"${businessError.code}: ${businessError.text}"))
-
-        case Left(technicalError: TechnicalError) =>
-          logger.error(s"[FinancialTransactionsService] HIP returned TechnicalError: ${technicalError.code} - ${technicalError.message}")
-          Left(Error(Status.INTERNAL_SERVER_ERROR, s"${technicalError.code}: ${technicalError.message}"))
-
-        case Left(otherFailure) =>
-          logger.error(s"[FinancialTransactionsService] Unexpected HIP error: $otherFailure")
-          Left(Error(Status.INTERNAL_SERVER_ERROR, "Unexpected HIP failure occurred"))
+        case Left(error: Error) => Left(error)
       }
     } else {
       logger.debug("[FinancialTransactionsService][getFinancialTransactions] " +
         s"Calling financialDataConnector with Regime: $regime\nParams: $queryParameters")
       connector.getFinancialData(regime, queryParameters).map {
         case Right(financialTransactions) =>
-          infoLog(s"[FinancialTransactionsService][getFinancialTransactions] successfully retrieved financial transactions. Attempting to remove invalid charges")
+          infoLog(s"[FinancialTransactionsService][getFinancialTransactions] " +
+            s"successfully retrieved financial transactions. Attempting to remove invalid charges")
           Right(financialTransactions.copy(documentDetails = ChargeTypes.removeInvalidCharges(financialTransactions.documentDetails)))
         case response: FinancialTransactionsResponse => response
       }

--- a/it/controllers/PenaltyDetailsComponentSpec.scala
+++ b/it/controllers/PenaltyDetailsComponentSpec.scala
@@ -16,12 +16,14 @@
 
 package controllers
 
-import config.RegimeKeys
+import config.{MicroserviceAppConfig, RegimeKeys}
 import helpers.ComponentSpecBase
-import helpers.servicemocks.EISPenaltyDetailsStub
+import helpers.servicemocks.{EISPenaltyDetailsStub, HIPPenaltyDetailsStub}
 import models.{PenaltyDetailsQueryParameters, VatRegime}
+import play.api.Application
 import play.api.http.Status._
 import play.api.libs.json.Json
+import play.api.test.Helpers.running
 import testData.PenaltyDetailsTestData
 
 
@@ -32,87 +34,139 @@ class PenaltyDetailsComponentSpec extends ComponentSpecBase {
     val vatRegime = VatRegime("123456789")
     lazy val queryParameters = PenaltyDetailsQueryParameters(dateLimit = Some("02"))
 
-    "a successful response is returned by the API" should {
+    "calling the IF API" when {
+      val app: Application = buildApp(Map("feature-switch.call-api-1812-hip" -> "false"))
+      "a successful response is returned by the API" should {
 
-      "return a success response" in {
+        "return a success response" in {
+          running(app) { implicit app: Application =>
+            isAuthorised()
 
-        isAuthorised()
+            And("I wiremock stub a successful Get Penalty Details response")
+            EISPenaltyDetailsStub.stubGetPenaltyDetails(
+              vatRegime, queryParameters)(OK, PenaltyDetailsTestData.penaltyDetailsAPIJson)
 
-        And("I wiremock stub a successful Get Penalty Details response")
-        EISPenaltyDetailsStub.stubGetPenaltyDetails(
-          vatRegime, queryParameters)(OK, PenaltyDetailsTestData.penaltyDetailsAPIJson)
+            When(s"I call GET /financial-transactions/penalty/${RegimeKeys.VAT}/${vatRegime.id}")
+            val res = PenaltyDetails.getPenaltyDetails(RegimeKeys.VAT, vatRegime.id, queryParameters)
 
-        When(s"I call GET /financial-transactions/penalty/${RegimeKeys.VAT}/${vatRegime.id}")
-        val res = PenaltyDetails.getPenaltyDetails(RegimeKeys.VAT, vatRegime.id, queryParameters)
+            Then("a successful response is returned with expected JSON data")
+            res should have(
+              httpStatus(OK),
+              jsonBodyAs(PenaltyDetailsTestData.penaltyDetailsWrittenJson)
+            )
+          }
+        }
+      }
 
-        Then("a successful response is returned with expected JSON data")
-        res should have(
-          httpStatus(OK),
-          jsonBodyAs(PenaltyDetailsTestData.penaltyDetailsWrittenJson)
-        )
+      "the API returns a success response with breathing space but no penalty data" should {
+
+        "return a success response with the breathing space data and no penalty data" in {
+          running(app) { implicit app: Application =>
+            isAuthorised()
+            And("I wiremock stub a successful Get Penalty Details response")
+            EISPenaltyDetailsStub.stubGetPenaltyDetails(
+              vatRegime, queryParameters)(OK, PenaltyDetailsTestData.penaltyDetailsAPIJsonBSOnly)
+            When(s"I call GET /financial-transactions/penalty/${RegimeKeys.VAT}/${vatRegime.id}")
+            val res = PenaltyDetails.getPenaltyDetails(RegimeKeys.VAT, vatRegime.id, queryParameters)
+
+            Then("a successful response is returned with a BS boolean and no penalty data")
+            res should have(
+              httpStatus(OK),
+              jsonBodyAs(PenaltyDetailsTestData.penaltyDetailsWrittenJsonBSOnly)
+            )
+          }
+        }
+      }
+
+      "the API returns a success response with empty JSON" should {
+
+        "return a success response with the breathing space boolean" in {
+          running(app) { implicit app: Application =>
+          isAuthorised()
+          And("I wiremock stub a successful Get Penalty Details response")
+          EISPenaltyDetailsStub.stubGetPenaltyDetails(
+            vatRegime, queryParameters)(OK, Json.obj())
+          When(s"I call GET /financial-transactions/penalty/${RegimeKeys.VAT}/${vatRegime.id}")
+          val res = PenaltyDetails.getPenaltyDetails(RegimeKeys.VAT, vatRegime.id, queryParameters)
+
+          Then("a successful response is returned with a BS boolean and no penalty data")
+          res should have(
+            httpStatus(OK),
+            jsonBodyAs(PenaltyDetailsTestData.penaltyDetailsWrittenJsonBSOnly)
+          )
+
+        }
       }
     }
 
-    "the API returns a success response with breathing space but no penalty data" should {
+      "an unsuccessful response is returned by the API" should {
 
-      "return a success response with the breathing space data and no penalty data" in {
+        lazy val queryParameters = models.PenaltyDetailsQueryParameters()
 
-        isAuthorised()
-        And("I wiremock stub a successful Get Penalty Details response")
-        EISPenaltyDetailsStub.stubGetPenaltyDetails(
-          vatRegime, queryParameters)(OK, PenaltyDetailsTestData.penaltyDetailsAPIJsonBSOnly)
-        When(s"I call GET /financial-transactions/penalty/${RegimeKeys.VAT}/${vatRegime.id}")
-        val res = PenaltyDetails.getPenaltyDetails(RegimeKeys.VAT, vatRegime.id, queryParameters)
+        "return an error response" in {
+          running(app) { implicit app: Application =>
+            isAuthorised()
 
-        Then("a successful response is returned with a BS boolean and no penalty data")
-        res should have(
-          httpStatus(OK),
-          jsonBodyAs(PenaltyDetailsTestData.penaltyDetailsWrittenJsonBSOnly)
-        )
+            And("I wiremock stub a bad request response from Get Financial Data")
+            EISPenaltyDetailsStub.stubGetPenaltyDetails(vatRegime, queryParameters)(BAD_REQUEST, PenaltyDetailsTestData.errorJson)
 
+            When(s"I call GET /financial-transactions/penalty/${RegimeKeys.VAT}/${vatRegime.id}")
+            val res = PenaltyDetails.getPenaltyDetails(RegimeKeys.VAT, vatRegime.id, queryParameters)
+
+            Then("an error is returned by the API with expected JSON data")
+            res should have(
+              httpStatus(BAD_REQUEST),
+              jsonBodyAs[models.API1812.Error](PenaltyDetailsTestData.errorModel)
+            )
+          }
+        }
       }
     }
 
-    "the API returns a success response with empty JSON" should {
+    "calling the HIP API" when {
+      val app: Application = buildApp(Map("feature-switch.call-api-1812-hip" -> "true"))
+      "a successful response is returned by the API" should {
+        "return a success response" in {
+          running(app) { implicit app: Application =>
+            isAuthorised()
 
-      "return a success response with the breathing space boolean" in {
+            And("I wiremock stub a successful Get Penalty Details response")
+            HIPPenaltyDetailsStub.stubGetPenaltyDetails(
+              vatRegime, queryParameters)(OK, PenaltyDetailsTestData.penaltyDetailsAPIJson)
 
-        isAuthorised()
-        And("I wiremock stub a successful Get Penalty Details response")
-        EISPenaltyDetailsStub.stubGetPenaltyDetails(
-          vatRegime, queryParameters)(OK, Json.obj())
-        When(s"I call GET /financial-transactions/penalty/${RegimeKeys.VAT}/${vatRegime.id}")
-        val res = PenaltyDetails.getPenaltyDetails(RegimeKeys.VAT, vatRegime.id, queryParameters)
+            When(s"I call GET /financial-transactions/penalty/${RegimeKeys.VAT}/${vatRegime.id}")
+            val res = PenaltyDetails.getPenaltyDetails(RegimeKeys.VAT, vatRegime.id, queryParameters)
 
-        Then("a successful response is returned with a BS boolean and no penalty data")
-        res should have(
-          httpStatus(OK),
-          jsonBodyAs(PenaltyDetailsTestData.penaltyDetailsWrittenJsonBSOnly)
-        )
-
+            Then("a successful response is returned with expected JSON data")
+            res should have(
+              httpStatus(OK),
+              jsonBodyAs(PenaltyDetailsTestData.penaltyDetailsWrittenJson)
+            )
+          }
+        }
       }
-    }
 
+      "an unsuccessful response is returned by the API" should {
 
-    "an unsuccessful response is returned by the API" should {
+        lazy val queryParameters = models.PenaltyDetailsQueryParameters()
 
-      lazy val queryParameters = models.PenaltyDetailsQueryParameters()
+        "return an error response" in {
+          running(app) { implicit app: Application =>
+            isAuthorised()
 
-      "return an error response" in {
+            And("I wiremock stub a bad request response from Get Financial Data")
+            HIPPenaltyDetailsStub.stubGetPenaltyDetails(vatRegime, queryParameters)(BAD_REQUEST, PenaltyDetailsTestData.errorJson)
 
-        isAuthorised()
+            When(s"I call GET /financial-transactions/penalty/${RegimeKeys.VAT}/${vatRegime.id}")
+            val res = PenaltyDetails.getPenaltyDetails(RegimeKeys.VAT, vatRegime.id, queryParameters)
 
-        And("I wiremock stub a bad request response from Get Financial Data")
-        EISPenaltyDetailsStub.stubGetPenaltyDetails(vatRegime, queryParameters)(BAD_REQUEST, PenaltyDetailsTestData.errorJson)
-
-        When(s"I call GET /financial-transactions/penalty/${RegimeKeys.VAT}/${vatRegime.id}")
-        val res = PenaltyDetails.getPenaltyDetails(RegimeKeys.VAT, vatRegime.id, queryParameters)
-
-        Then("an error is returned by the API with expected JSON data")
-        res should have(
-          httpStatus(BAD_REQUEST),
-          jsonBodyAs[models.API1812.Error](PenaltyDetailsTestData.errorModel)
-        )
+            Then("an error is returned by the API with expected JSON data")
+            res should have(
+              httpStatus(BAD_REQUEST),
+              jsonBodyAs[models.API1812.Error](PenaltyDetailsTestData.errorModel)
+            )
+          }
+        }
       }
     }
   }

--- a/it/helpers/ComponentSpecBase.scala
+++ b/it/helpers/ComponentSpecBase.scala
@@ -52,7 +52,8 @@ trait ComponentSpecBase extends TestSuite with CustomMatchers
     "microservice.services.des.url" -> mockUrl,
     "microservice.services.eis.url" -> mockUrl,
     "microservice.services.hip.url" -> mockUrl,
-    "microservice.services.hip.port" -> mockPort
+    "microservice.services.hip.port" -> mockPort,
+    "feature-switch.enable1811HIPCall" -> false.toString
   )
 
   def stubGetRequest(url: String, returnStatus: Int, returnBody: String): StubMapping =
@@ -73,6 +74,12 @@ trait ComponentSpecBase extends TestSuite with CustomMatchers
     .in(Environment.simple(mode = Mode.Dev))
     .configure(config)
     .build()
+
+  def buildApp(extraConfig: Map[String, String] = Map.empty): Application =
+    new GuiceApplicationBuilder()
+      .in(Environment.simple(mode = Mode.Dev))
+      .configure(config ++ extraConfig)
+      .build()
 
   override def beforeAll(): Unit = {
     super.beforeAll()

--- a/it/helpers/ComponentSpecBase.scala
+++ b/it/helpers/ComponentSpecBase.scala
@@ -52,8 +52,7 @@ trait ComponentSpecBase extends TestSuite with CustomMatchers
     "microservice.services.des.url" -> mockUrl,
     "microservice.services.eis.url" -> mockUrl,
     "microservice.services.hip.url" -> mockUrl,
-    "microservice.services.hip.port" -> mockPort,
-    "feature-switch.enable1811HIPCall" -> false.toString
+    "microservice.services.hip.port" -> mockPort
   )
 
   def stubGetRequest(url: String, returnStatus: Int, returnBody: String): StubMapping =

--- a/it/helpers/servicemocks/HIPFinancialDetailsStub.scala
+++ b/it/helpers/servicemocks/HIPFinancialDetailsStub.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package helpers.servicemocks
+
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
+import helpers.WiremockHelper.stubPost
+import play.api.libs.json.{JsValue, Json}
+
+object HIPFinancialDetailsStub {
+
+  val financialDetailsUrl = "/etmp/RESTAdapter/cross-regime/taxpayer/financial-data/query"
+
+  def stubGetFinancialDetails(status: Int, response: JsValue): StubMapping =
+    stubPost(financialDetailsUrl, status, response.toString())
+
+  def businessErrorResponse(code: String, text: String): JsValue = Json.obj(
+    "errors" -> Json.obj(
+      "processingDate" -> "2025-01-31T09:30:47Z",
+      "code" -> code,
+      "text" -> text
+    )
+  )
+
+  def technicalErrorResponse(code: String, message: String, logId: String = "C0000AB8190C333200000002000007A6"): JsValue = Json.obj(
+    "error" -> Json.obj(
+      "code" -> code,
+      "message" -> message,
+      "logID" -> logId
+    )
+  )
+
+  def hipWrappedErrorResponse(errorType: String, reason: String): JsValue = Json.obj(
+    "origin" -> "HIP",
+    "response" -> Json.obj(
+      "failures" -> Json.arr(Json.obj(
+        "type" -> errorType,
+        "reason" -> reason
+      ))
+    )
+  )
+
+  def noDataSuccessResponse(): JsValue = Json.obj(
+    "success" -> Json.obj(
+      "processingDate" -> "2025-01-31T09:30:47Z"
+    )
+  )
+
+}

--- a/it/testData/FinancialDataHIP1811.scala
+++ b/it/testData/FinancialDataHIP1811.scala
@@ -22,7 +22,7 @@ import java.time.LocalDate
 
 object FinancialDataHIP1811 {
 
-  val fullFinancialTransactionsJsonHIP: JsObject = Json.obj(
+  val financialDetailsInHipWrapperJson: JsObject = Json.obj(
     "success" -> Json.obj(
     "processingDate" -> "2024-12-31T13:34:56Z",
     "financialData" -> Json.obj(
@@ -102,6 +102,38 @@ object FinancialDataHIP1811 {
       )
     )
   )
+
+  val financialTransactionsResultJson: JsObject = Json.obj(
+    "financialTransactions" -> Json.arr(
+      Json.obj(
+        "chargeType" -> "VAT Return Debit Charge",
+        "periodKey" -> "22A1",
+        "taxPeriodFrom" -> "2022-01-01",
+        "taxPeriodTo" -> "2022-01-31",
+        "chargeReference" -> "XP001286394838",
+        "mainTransaction" -> "4700",
+        "subTransaction" -> "1174",
+        "originalAmount" -> 100,
+        "outstandingAmount" -> 0,
+        "clearedAmount" -> 100,
+        "items" -> Json.arr(
+          Json.obj(
+            "dueDate" -> "2022-02-08",
+            "amount" -> 3420,
+            "clearingDate" -> "2022-02-09",
+            "clearingReason" -> "Payment at External Payment Collector Reported",
+            "clearingSAPDocument" -> "719283701921",
+            "DDcollectionInProgress" -> true
+          )
+        ),
+        "accruingInterestAmount" -> 12.1,
+        "accruingPenaltyAmount" -> 10.01,
+        "penaltyType" -> "LPP1"
+      )
+    ),
+    "hasOverdueChargeAndNoTTP" -> false
+  )
+
   val lineItems: LineItemDetails = LineItemDetails(
     mainTransaction = Some("4700"),
     subTransaction = Some("1174"),

--- a/test/connectors/API1811/httpParsers/FinancialTransactionsHttpHIPParserSpec.scala
+++ b/test/connectors/API1811/httpParsers/FinancialTransactionsHttpHIPParserSpec.scala
@@ -18,6 +18,7 @@ package connectors.API1811.httpParsers
 
 import base.SpecBase
 import connectors.API1811.httpParsers.FinancialTransactionsHttpHIPParser._
+import models.API1811.Error
 import play.api.http.Status
 import play.api.http.Status._
 import uk.gov.hmrc.http.HttpResponse
@@ -49,29 +50,29 @@ class FinancialTransactionsHttpHIPParserSpec extends SpecBase {
     "parsing an UNPROCESSABLE_ENTITY response" should {
       def errorResponse(responseBody: String): HttpResponse = HttpResponse.apply(status = UNPROCESSABLE_ENTITY, responseBody)
 
-      "return a FinancialTransactionsNoContent response" when {
+      "return a NOT_FOUND Error response" when {
         "able to validate a HIP BusinessError body with a '016' failure code and text" in {
           val noDataFailureResponseBody = """{"errors":{"processingDate":"2025-03-03", "code":"016", "text":"Invalid ID Number"}}"""
           val notFoundHttpResponse = errorResponse(noDataFailureResponseBody)
 
           val result = financialTransactionsParserReads(notFoundHttpResponse)
-          result shouldBe Left(FinancialTransactionsNoContent)
+          result shouldBe Left(Error(NOT_FOUND, "ID number did not match any penalty data"))
         }
         "able to validate a HIP BusinessError body with a '018' failure code and text" in {
           val noDataFailureResponseBody = """{"errors":{"processingDate":"2025-03-03", "code":"018", "text":"No Data Identified"}}"""
           val notFoundHttpResponse = errorResponse(noDataFailureResponseBody)
 
           val result = financialTransactionsParserReads(notFoundHttpResponse)
-          result shouldBe Left(FinancialTransactionsNoContent)
+          result shouldBe Left(Error(NOT_FOUND, "ID number did not match any financial data"))
         }
       }
-      "return a 422 FinancialTransactionsFailureResponse" when {
+      "return an UNPROCESSABLE_ENTITY Error response" when {
         "HIP BusinessError body does not have correct '016' failure code" in {
           val bodyWithInvalidCode = """{"errors":{"processingDate":"2025-03-03", "code":"16", "text":"Invalid ID Number"}}"""
           val notFoundNoBodyHttpResponse = errorResponse(bodyWithInvalidCode)
 
           val result = financialTransactionsParserReads(notFoundNoBodyHttpResponse)
-          result shouldBe Left(FinancialTransactionsFailureResponse(UNPROCESSABLE_ENTITY))
+          result shouldBe Left(Error(UNPROCESSABLE_ENTITY, "16 - Invalid ID Number"))
         }
       }
 
@@ -81,7 +82,7 @@ class FinancialTransactionsHttpHIPParserSpec extends SpecBase {
 
         val result = financialTransactionsParserReads(notFoundNoBodyHttpResponse)
 
-        result shouldBe Left(FinancialTransactionsFailureResponse(UNPROCESSABLE_ENTITY))
+        result shouldBe Left(Error(UNPROCESSABLE_ENTITY, "016 - Invalid id num."))
       }
     }
     "response body cannot be validated as a BusinessError" in {
@@ -89,17 +90,17 @@ class FinancialTransactionsHttpHIPParserSpec extends SpecBase {
       val notFoundHttpResponse = HttpResponse.apply(status = UNPROCESSABLE_ENTITY, body = invalidBody)
 
       val result = financialTransactionsParserReads(notFoundHttpResponse)
-      result shouldBe Left(FinancialTransactionsFailureResponse(UNPROCESSABLE_ENTITY))
+      result shouldBe Left(Error(UNPROCESSABLE_ENTITY, invalidBody))
     }
   }
 
-  "will return a HIPFinancialDetailsFailureResponse" when {
+  "will return an INTERNAL_SERVER_ERROR response" when {
     "parsing an error with a TechnicalError response body" in {
       val technicalError = """{"response":{"error":{"code":"errorCode","message":"errorMessage","logId":"errorLogId"}}}"""
       val technicalErrorResponse = HttpResponse(status = INTERNAL_SERVER_ERROR, body = technicalError)
 
         val result = financialTransactionsParserReads(technicalErrorResponse)
-        result shouldBe Left(FinancialTransactionsFailureResponse(INTERNAL_SERVER_ERROR))
+        result shouldBe Left(Error(INTERNAL_SERVER_ERROR, "errorCode - errorMessage"))
       }
     }
 
@@ -112,7 +113,7 @@ class FinancialTransactionsHttpHIPParserSpec extends SpecBase {
       val technicalErrorResponse = HttpResponse(status = BAD_REQUEST, body = hipWrappedError)
 
         val result = financialTransactionsParserReads(technicalErrorResponse)
-        result shouldBe Left(FinancialTransactionsFailureResponse(BAD_REQUEST))
+        result shouldBe Left(Error(BAD_REQUEST, "errorType - errorReason,\nerrorType2 - errorReason2"))
     }
 
     "response body cannot be parsed as expected error format" in {
@@ -120,13 +121,13 @@ class FinancialTransactionsHttpHIPParserSpec extends SpecBase {
       val notFoundHttpResponse = HttpResponse.apply(status = CONFLICT, body = invalidBody)
 
       val result = financialTransactionsParserReads(notFoundHttpResponse)
-      result shouldBe Left(FinancialTransactionsFailureResponse(CONFLICT))
+      result shouldBe Left(Error(CONFLICT, invalidBody))
     }
 
     "parsing an unknown error (e.g. IM A TEAPOT - 418) - and log a PagerDuty" in {
       val imATeapotHttpResponse = HttpResponse.apply(status = IM_A_TEAPOT, body = "I'm a teapot.")
 
       val result = financialTransactionsParserReads(imATeapotHttpResponse)
-      result shouldBe Left(FinancialTransactionsFailureResponse(IM_A_TEAPOT))
+      result shouldBe Left(Error(IM_A_TEAPOT, "I'm a teapot."))
     }
 }


### PR DESCRIPTION
Because custom errors were being returned in the parser, they were all being turned into generic InternalServerErrors in the service as they don't match the pattern match. Have made it consistent with what it was.
Some tests weren't testing HIP versions, and some tests would fail if you changed the switches in config before running because they weren't handling the switch state themselves.